### PR TITLE
Checkpointing a POUNCE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 **/*.rs.bk
 .env
 .DS_Store
+**/*.code-workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
+ "terminal_size",
  "textwrap",
 ]
 
@@ -395,6 +396,16 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -776,6 +787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "file-per-thread-logger"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +822,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -839,6 +874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,9 +898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1032,6 +1076,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -1198,6 +1264,12 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leb128"
@@ -1325,6 +1397,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1434,24 @@ dependencies = [
  "mime",
  "spin 0.9.4",
  "version_check",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1402,6 +1502,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "openssl"
+version = "0.10.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
 
 [[package]]
 name = "percent-encoding"
@@ -1475,6 +1620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
 name = "polling"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1637,17 @@ dependencies = [
  "log",
  "wepoll-ffi",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "pounce"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "reqwest",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1596,11 +1758,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -1667,6 +1828,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,10 +1852,13 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1694,6 +1867,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "url",
@@ -1779,6 +1953,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,19 +1985,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.149"
+name = "security-framework"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1850,13 +2057,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serval"
-version = "0.1.0"
-dependencies = [
- "clap",
 ]
 
 [[package]]
@@ -1986,6 +2186,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,10 +2209,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+dependencies = [
+ "rustix 0.36.5",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "terminal_size",
+]
 
 [[package]]
 name = "thiserror"
@@ -2075,6 +2302,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2193,6 +2430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2540,7 @@ dependencies = [
  "log",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "daemon",
   "engine",
   "once",
+  "pounce",
   "queuey-queue",
   "utils"
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,5 +14,6 @@ http = "0.2.8"
 log = "0.4.17"
 reqwest = { version = "0.11.13",  default-features = false, features = ["brotli", "json", "rustls"] }
 serde = { version = "1.0.149", features = ["serde_derive"] }
+serde_json = "1.0.89"
 tokio =  { version = "1.23.0", features = ["full"] }
 uuid = { workspace = true }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use axum::{
-    extract::{Extension, Multipart},
+    extract::{Multipart, State},
     http::{Request, StatusCode},
     middleware::{self, Next},
     response::Response,
@@ -11,41 +11,52 @@ use dotenvy::dotenv;
 use engine::ServalEngine;
 use http::header::HeaderValue;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use uuid::Uuid;
 
 use std::collections::HashMap;
-use std::ops::Deref;
-use std::{net::SocketAddr, sync::Arc};
-
-#[derive(Clone)]
-struct RunnerState {
-    engine: ServalEngine,
-    history: RunnerHistory,
-}
+use std::net::SocketAddr;
+use std::sync::Arc;
 
 #[derive(Clone, Serialize)]
-struct RunnerHistory {
+struct RunnerState {
     jobs: HashMap<String, JobMetadata>,
     total: usize,
+    errors: usize,
 }
 
 impl RunnerState {
-    pub fn new() -> Result<Self> {
-        let engine = ServalEngine::new()?;
-        let history = RunnerHistory {
+    pub fn new() -> Self {
+        RunnerState {
             total: 0,
+            errors: 0,
             jobs: HashMap::new(),
-        };
-        Ok(Self { engine, history })
+        }
     }
 }
 
+type AppState = Arc<Mutex<RunnerState>>;
+
 #[derive(Clone, Serialize, Deserialize)]
 struct JobMetadata {
-    id: uuid::Uuid,
+    id: Uuid,
     name: String,
     description: String,
-    update_url: String, // for the moment
+    status_url: String, // for the moment
     result_url: String, // for the moment
+}
+
+impl From<Envelope> for JobMetadata {
+    fn from(envelope: Envelope) -> Self {
+        let id = Uuid::new_v4();
+        Self {
+            id,
+            name: envelope.name.clone(),
+            description: envelope.description,
+            status_url: format!("/jobs/{}/status", id),
+            result_url: format!("/jobs/{}/result", id),
+        }
+    }
 }
 
 /// Remember what is important.
@@ -63,24 +74,93 @@ async fn ping() -> String {
     "pong".to_string()
 }
 
-/// Unimplemented main worker endpoint.
-async fn incoming(
-    Extension(mut state): Extension<Arc<RunnerState>>,
-    mut multipart: Multipart,
-) -> (StatusCode, String) {
-    let Some(mut state) = Arc::get_mut(&mut state) else {
-        return (StatusCode::INTERNAL_SERVER_ERROR, "failed to read app state".to_string());
-    };
-
-    state.history.total += 1;
-
-    // chomp up form input here
-
-    (StatusCode::ACCEPTED, "acccepted".to_string())
+#[derive(Clone, Debug, Deserialize)]
+struct Envelope {
+    name: String,
+    description: String,
 }
 
-async fn monitor_history(Extension(state): Extension<Arc<RunnerState>>) -> Json<RunnerHistory> {
-    Json(state.deref().history.clone())
+/// Unimplemented main worker endpoint.
+async fn incoming(state: State<AppState>, mut multipart: Multipart) -> (StatusCode, String) {
+    let mut envelope: Option<Envelope> = None;
+    let mut binary: Option<Vec<u8>> = None;
+
+    // chomp up form input here
+    while let Some(field) = multipart.next_field().await.unwrap() {
+        let name = field.name().unwrap().to_string();
+        let data = field.bytes().await.unwrap();
+        match name.as_str() {
+            "envelope" => {
+                let data = data.to_vec();
+                let Ok(parsed) = serde_json::from_slice(&data) else {
+                    // this is not good enough
+                    return (StatusCode::BAD_REQUEST, "job envelope is invalid".to_string());
+                };
+                envelope = Some(parsed);
+            }
+            "executable" => {
+                binary = Some(data.to_vec());
+            }
+            _ => {
+                log::info!("ignoring unknown field `{name}`");
+            }
+        }
+    }
+
+    if binary.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            "no wasm executable data provided!".to_string(),
+        );
+    }
+
+    let envelope = envelope.unwrap_or(Envelope {
+        name: "unknown".to_string(),
+        description: "unknown job description".to_string(),
+    });
+    let metadata: JobMetadata = JobMetadata::from(envelope);
+    let binary = binary.unwrap();
+    log::info!(
+        "received WASM job; name={}; executable length={}",
+        metadata.name,
+        binary.len()
+    );
+
+    // Poor human's history tracking here. We'll need to do better at some point.
+    // E.g., handle overflows. That would be some nice uptime.
+    let mut state = state.lock().await;
+    state.total += 1;
+    state.jobs.insert(metadata.id.to_string(), metadata.clone());
+
+    // What we'll do later is accept this job for processing and send it to a thread or something.
+    // But for now we do it right here, in our handler.
+    // The correct response by design is a 202 Accepted plus the metadata object.
+    match execute_job(&metadata, binary).await {
+        Ok(v) => (StatusCode::OK, v),
+        Err(e) => {
+            state.errors += 1;
+            (StatusCode::BAD_REQUEST, e.to_string())
+        }
+    }
+}
+
+/// Run a job in the wasm engine.
+async fn execute_job(metadata: &JobMetadata, executable: Vec<u8>) -> anyhow::Result<String> {
+    log::info!(
+        "about to run job name={}; id={}",
+        metadata.name,
+        metadata.id
+    );
+    let mut engine = ServalEngine::new()?;
+    let bytes = engine.execute(&executable, None)?;
+    let contents = String::from_utf8(bytes)?;
+
+    Ok(contents)
+}
+
+async fn monitor_history(state: State<AppState>) -> Json<RunnerState> {
+    let state = state.lock().await;
+    Json(state.clone())
 }
 
 #[tokio::main]
@@ -89,16 +169,16 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let host = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
-    let port = std::env::var("PORT").unwrap_or_else(|_| "8000".to_string());
+    let port = std::env::var("PORT").unwrap_or_else(|_| "8100".to_string());
 
-    let state = RunnerState::new()?;
+    let state = Arc::new(Mutex::new(RunnerState::new()));
 
     let app = Router::new()
         .route("/monitor/ping", get(ping))
         .route("/monitor/history", get(monitor_history))
         .route("/jobs", post(incoming))
         .route_layer(middleware::from_fn(clacks))
-        .with_state(Arc::new(state));
+        .with_state(state);
 
     let addr = format!("{}:{}", host, port);
     log::info!("wait-for-it daemon listening on {}", &addr);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -22,11 +22,19 @@ impl ServalEngine {
     pub fn execute(
         &mut self,
         binary: &[u8],
-        input: ReadPipe<Cursor<String>>,
+        input: Option<ReadPipe<Cursor<String>>>,
     ) -> anyhow::Result<Vec<u8>> {
         let stdout = WritePipe::new_in_memory();
+
+        let stdin = match input {
+            Some(v) => v,
+            None => {
+                ReadPipe::from("".to_string())
+            }
+        };
+
         let wasi = WasiCtxBuilder::new()
-            .stdin(Box::new(input))
+            .stdin(Box::new(stdin))
             .stdout(Box::new(stdout.clone()))
             .inherit_stderr()
             .build();

--- a/once/src/main.rs
+++ b/once/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> anyhow::Result<()> {
     let stdin = ReadPipe::from(payload);
     let binary = fs::read(exec_path)?;
 
-    let bytes = engine.execute(&binary, stdin)?;
+    let bytes = engine.execute(&binary, Some(stdin))?;
     let contents = String::from_utf8(bytes)?;
     println!("raw output:\n{}", contents);
 

--- a/pounce/Cargo.toml
+++ b/pounce/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pounce"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { version = "3.2.23", features = ["derive", "wrap_help"] } # older version on purpose
+reqwest = { version = "0.11.13", features = ["blocking", "brotli", "json", "multipart", "rustls"] }
+serde_json = "1.0.89"
+uuid = { workspace = true }

--- a/pounce/src/main.rs
+++ b/pounce/src/main.rs
@@ -1,0 +1,158 @@
+#![forbid(unsafe_code)]
+#![deny(future_incompatible)]
+#![warn(
+    missing_debug_implementations,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_qualifications
+)]
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
+use uuid::Uuid;
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(name = "pounce 🐈", version)]
+/// Interacts with the running serval agent daemon via its http API.
+struct Args {
+    #[clap(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum Command {
+    /// Run the specified WASM binary.
+    #[clap(display_order = 1)]
+    Run {
+        /// A descriptive name for the job
+        #[clap(long, short)]
+        name: Option<String>,
+        /// A description for the job
+        #[clap(long, short)]
+        description: Option<String>,
+        /// The file containing the wasm binary to run. Omit to read from stdin.
+        #[clap(value_name = "FILE")]
+        file: Option<PathBuf>,
+    },
+    /// Get the status of a job in progress.
+    #[clap(display_order = 2)]
+    Status { id: Uuid },
+    /// Get results for a job run, given its ID.
+    #[clap(display_order = 3)]
+    Results { id: Uuid },
+    /// Get full job run history from the running process.
+    #[clap(display_order = 4)]
+    History,
+}
+
+/// Convenience function to build urls repeatably.
+fn build_url(path: String) -> String {
+    let baseurl =
+        std::env::var("SERVAL_NODE_URL").unwrap_or_else(|_| "http://localhost:8100".to_string());
+    format!("{baseurl}/{path}")
+}
+
+/// Convenience function to read an input wasm binary either from a pathbuf or from stdin.
+fn read_binary(maybepath: Option<PathBuf>) -> Result<Vec<u8>, anyhow::Error> {
+    // TODO This implementation should become a streaming implementation.
+    let mut binary: Vec<u8> = Vec::new();
+    let size = if let Some(ref fpath) = maybepath {
+        let file = File::open(fpath)?;
+        let mut reader = BufReader::new(file);
+        reader.read_to_end(&mut binary)?
+    } else {
+        let mut reader = BufReader::new(std::io::stdin());
+        reader.read_to_end(&mut binary)?
+    };
+
+    if size == 0 {
+        Err(anyhow!("no executable data read!"))
+    } else {
+        Ok(binary)
+    }
+}
+
+/// Post a wasm executable to a waiting agent to run.
+fn run(
+    name: Option<String>,
+    description: Option<String>,
+    maybepath: Option<PathBuf>,
+) -> Result<()> {
+    let binary = read_binary(maybepath)?;
+    let binary_part = reqwest::blocking::multipart::Part::bytes(binary);
+
+    let envelope = serde_json::json!({
+        "id": &Uuid::new_v4().to_string(),
+        "name": name.unwrap_or_else(|| "temp-name".to_string()),
+        "description": description.unwrap_or_else(|| "posted via command-line".to_string())
+    });
+    let envelope_part = reqwest::blocking::multipart::Part::text(envelope.to_string());
+
+    let client = reqwest::blocking::Client::new();
+    let form = reqwest::blocking::multipart::Form::new()
+        .part("envelope", envelope_part)
+        .part("executable", binary_part);
+
+    let url = build_url("jobs".to_string());
+    let response = client.post(&url).multipart(form).send()?;
+
+    let body = response.text()?;
+
+    println!("{body}");
+
+    Ok(())
+}
+
+/// Get a job's status from a serval agent node.
+fn status(id: Uuid) -> Result<()> {
+    let url = build_url(format!("jobs/{id}/status"));
+    let response = reqwest::blocking::get(&url)?;
+    let body: serde_json::Map<String, serde_json::Value> = response.json()?;
+    println!("{}", serde_json::to_string_pretty(&body)?);
+
+    Ok(())
+}
+
+/// Get a job's results from a serval agent node.
+fn results(id: Uuid) -> Result<()> {
+    let url = build_url(format!("jobs/{id}/results"));
+    let response = reqwest::blocking::get(&url)?;
+    let body: serde_json::Map<String, serde_json::Value> = response.json()?;
+    println!("{}", serde_json::to_string_pretty(&body)?);
+
+    Ok(())
+}
+
+/// Get in-memory history from an agent node.
+fn history() -> Result<()> {
+    let url = build_url("monitor/history".to_string());
+    let response = reqwest::blocking::get(&url)?;
+    let body: serde_json::Map<String, serde_json::Value> = response.json()?;
+    println!("{}", serde_json::to_string_pretty(&body)?);
+
+    Ok(())
+}
+
+/// Parse command-line arguments and act.
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    match args.cmd {
+        Command::Run {
+            name,
+            description,
+            file,
+        } => {
+            run(name, description, file)?;
+        }
+        Command::Results { id } => results(id)?,
+        Command::Status { id } => status(id)?,
+        Command::History => history()?,
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
The daemon now accepts binary payloads, runs them, and responds with the results. There is a new CLI that exercises this behavior.

The engine runs the wasm immediately and does not queue it for processing, but at least it's bootstrapped.

Next up: porting over the code from meshy-mesh to find our job queue servers!