### PR TITLE
Support for writing output to a file, and stop dumping binary data out to the terminal

### DIFF
--- a/pounce/src/main.rs
+++ b/pounce/src/main.rs
@@ -49,7 +49,7 @@ pub enum Command {
         /// Path to a file to pass to the binary; omit to read from stdin (if present)
         #[clap(value_name = "OPTIONAL INPUT TO WASM BINARY")]
         input_file: Option<PathBuf>,
-        /// Path to write the output of the job to omit to write from stdout.
+        /// Path to write the output of the job. Omit to write to stdout.
         output_file: Option<PathBuf>,
     },
     /// Get the status of a job in progress.


### PR DESCRIPTION
## Examples
### Non-UTF-8 binary data won't be written to the terminal
````
prose:serval-mesh (main) 💖 cargo run --bin pounce -- run ../wasm-samples/thumbnailer/target/wasm32-wasi/release/thumbnailer.wasm ../wasm-samples/thumbnailer/sample.jpg -      
Sending unnamed to serval agent...
Response is non-printable binary data; redirect output to a file or provide an output filename to retrieve it.
````

### Output can be written to a file
````
prose:serval-mesh (main) 💖 cargo run --bin pounce -- run ../wasm-samples/thumbnailer/target/wasm32-wasi/release/thumbnailer.wasm ../wasm-samples/thumbnailer/sample.jpg out.jpg
Sending unnamed to serval agent...
Writing output to "out.jpg"
````

### Printable data _will_ be written to the terminal
(We might want a parameter to override this, a la `gzip -f`).
````
prose:serval-mesh (main) 💖 cargo run --bin pounce -- run ../wasm-samples/uppercaserizer/target/wasm32-wasi/release/uppercaserizer.wasm ../wasm-samples/README.md -
Sending unnamed to serval agent...
Output follows:
----------
# WASM-SAMPLES

THIS IS A COLLECTION OF SAMPLE WASM APPLICATIONS, INTENDED TO BE USED TO DEMONSTRATE VARIOUS PIECES OF FUNCTIONALITY AS WE DEVELOP THEM.

<snip>
````

