### PR TITLE
Gracefully handle WASM binaries that call proc_exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ name = "engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "utils",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow = { workspace = true }
+utils = { path = "../utils" }
 wasi-common = "3.0.1"
 wasmtime = "3.0.1"
 wasmtime-wasi = "3.0.1"

--- a/serval-agent/src/main.rs
+++ b/serval-agent/src/main.rs
@@ -151,6 +151,7 @@ async fn incoming(state: State<AppState>, mut multipart: Multipart) -> Response 
     // What we'll do later is accept this job for processing and send it to a thread or something.
     // But for now we do it right here, in our handler.
     // The correct response by design is a 202 Accepted plus the metadata object.
+    // TODO: SER-38 - capture exit code for failed jobs
     match execute_job(&metadata, binary, input).await {
         Ok(v) => (StatusCode::OK, v).into_response(),
         Err(e) => {

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -19,4 +19,6 @@ pub enum ServalError {
     //
     //     #[error("an error we have no more details about happened")]
     //     Unknown,
+    #[error("binary terminated with non-zero exit code")]
+    NonZeroExitCode(i32),
 }


### PR DESCRIPTION
The shenanigans required to get the exit code out of wasmtime/wasi was pretty comical; I ended up having to go read [the PR that originally landed their `I32Exit` struct](https://github.com/bytecodealliance/wasmtime/pull/5149/files#diff-b40e73525b97692c795ab25a67465a393fa6a17a4fcb5ee7009ab3d3345bc91dR542) to figure out how I was supposed to use it. :scream:

Anyhow, we no longer barf with an error if a job calls WASI's `proc_exit` (aka `std::process::exit(...)` in Rust Land) with an exit code of 0.

Two big TODOs fell out of this:
- [SER-37](https://linear.app/srvl/issue/SER-37/capture-output-of-jobs-even-if-they-exit-with-an-error) - we don't have a way to plumb the job's stdout through to callers when the job exits with an error
- [SER-38](https://linear.app/srvl/issue/SER-38/capture-wasi-exit-code-for-failed-jobs) - we should capture exit code as part of the Job struct