### PR TITLE
Fix ser-37: capture job output even on abnormal termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "log",
  "mdns-sd",
  "thiserror",
+ "wasi-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ mdns-sd = { version = "0.5.9", default-features = false, features = ["async"] }
 tokio = { version = "1.22.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["io"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+wasi-common = "3.0.1"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -9,6 +9,6 @@ license = "BSD-2-Clause-Patent"
 [dependencies]
 anyhow = { workspace = true }
 utils = { path = "../utils" }
-wasi-common = "3.0.1"
+wasi-common = { workspace = true }
 wasmtime = "3.0.1"
 wasmtime-wasi = "3.0.1"

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -73,9 +73,13 @@ fn main() -> anyhow::Result<()> {
     let stdin = payload.as_bytes();
     let binary = fs::read(exec_path)?;
 
-    let bytes = engine.execute(&binary, stdin)?;
-    let contents = String::from_utf8(bytes)?;
-    println!("raw output:\n{}", contents);
+    let result = engine.execute(&binary, stdin)?;
+    eprintln!(
+        "\nWASM executable exited with status code = {}",
+        result.code
+    );
+    println!("stdout:\n{}", String::from_utf8(result.stdout)?);
+    println!("stderr:\n{}", String::from_utf8(result.stderr)?);
 
     Ok(())
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,3 +12,4 @@ if-addrs = "0.7.0"
 log = {workspace = true }
 mdns-sd = { workspace = true }
 thiserror = "1.0.38"
+wasi-common = { workspace = true }

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -1,4 +1,7 @@
 use thiserror::Error;
+use wasi_common;
+
+use crate::structs::WasmResult;
 
 // A starting point for our internal errors. We can break this up or
 // rename things if we decide to. The goal here is to start using named
@@ -9,16 +12,23 @@ use thiserror::Error;
 /// Error types used by internal serval libraries to communicate details about
 /// errors specific to our implementation details.
 pub enum ServalError {
+    /// If this ever happens, Mark owes you a quarter.
     #[error("unable to find a free port >= `{0}`")]
     NoFreePorts(u16),
 
+    /// MDNS failed for some reason. We wrap up the mdns library's error here.
     #[error("unable to set up mdns")]
     MdnsError(#[from] mdns_sd::Error),
+
     //     #[error("an example of a more complex error type (expected {expected:?}, found {found:?})")]
     //     InvalidHeader { expected: String, found: String },
     //
     //     #[error("an error we have no more details about happened")]
     //     Unknown,
-    #[error("binary terminated with non-zero exit code")]
-    NonZeroExitCode(i32),
+    #[error("the WASM executable terminated abnormally; code={}", result.code)]
+    AbnormalWasmExit { result: WasmResult },
+
+    /// The WASMtime engine responded with an error.
+    #[error("wasmtime engine error")]
+    WasmEngineError(#[from] wasi_common::Error),
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod mdns;
 pub mod networking;
+pub mod structs;

--- a/utils/src/structs.rs
+++ b/utils/src/structs.rs
@@ -1,0 +1,10 @@
+/// The results of running a WASM executable.
+#[derive(Debug)]
+pub struct WasmResult {
+    /// The status code returned by the execution; 0 for normal termination.
+    pub code: i32,
+    /// Whatever the WASM executable wrote to stdout.
+    pub stdout: Vec<u8>,
+    /// Whatever the WASM executable wrote to stderr.
+    pub stderr: Vec<u8>,
+}


### PR DESCRIPTION
Introduced a struct to hold full job output, `WasmResult`, and put it to use in the engine and its consumers. `WasmResult` has fields for status code, stderr, and stdout, and we populate these for both normal exits and errors.

Replaced the `NonZeroExitCode` error type with `AbnormalWasmExit`, which contains the full result struct for use by the caller.

Updated the test runner and the agent to use the new types. Added a new custom error type that wraps wasi-common errors. Pulled wasi-common into the workspace deps so we version lock that now that the utils lib uses it as well as the engine lib.

I don't yet have an example of a wasm executable that errors to test this with! We should write one.