### PR TITLE
Initial work toward an SDK

### DIFF
--- a/engine/src/runtime/helpers.rs
+++ b/engine/src/runtime/helpers.rs
@@ -3,11 +3,9 @@ use std::mem::size_of;
 use anyhow::anyhow;
 use wasmtime::{Caller, Extern, Memory, Val};
 
-///
 /// Calls into the guest environment to allocate a chunk of memory of the given size. if the guest
 /// does not expose a compatible alloc function, this will fail, and data exchange with the guest
 /// will not be possible. Our SDK automatically provides guest apps with this function.
-///
 pub fn alloc<T>(
     caller: &mut Caller<'_, T>,
     num_bytes_required: usize,
@@ -30,9 +28,7 @@ pub fn alloc<T>(
     Ok(ptr as usize)
 }
 
-///
 /// Returns a handle to the exported guest function with the given name, or an error if none exists.
-///
 pub fn get_func_from_caller<T>(
     caller: &mut Caller<'_, T>,
     export_name: &str,
@@ -44,9 +40,7 @@ pub fn get_func_from_caller<T>(
     Ok(f)
 }
 
-///
 /// Returns a handle to the guest environment's Memory object.
-///
 pub fn get_memory_from_caller<T>(caller: &mut Caller<'_, T>) -> Result<Memory, ()> {
     let Some(Extern::Memory(mem)) = caller.get_export("memory") else {
         return Err(());
@@ -55,9 +49,7 @@ pub fn get_memory_from_caller<T>(caller: &mut Caller<'_, T>) -> Result<Memory, (
     Ok(mem)
 }
 
-///
 /// Reads `len` bytes of data from the guest's memory starting at `ptr`.
-///
 pub fn read_bytes<T>(
     caller: &Caller<'_, T>,
     memory: Memory,
@@ -72,7 +64,6 @@ pub fn read_bytes<T>(
     Ok(buf)
 }
 
-///
 /// Writes the given data into the guest's memory, prefixed with a u32 indicating how many bytes of
 /// data were written. That is, if we want write the bytes [10, 20, 30, 40], this function will
 /// actually allocate 8 bytes total: 4 bytes for a u32 indicating the length of the data, followed by
@@ -80,7 +71,6 @@ pub fn read_bytes<T>(
 /// memory containing the byte sequence [4, 0, 0, 0, 10, 20, 30, 40].
 /// A peer function to this one (to go from a pointer in shared memory to a Vec<u8> containing data)
 /// exists in the SDK as `get_bytes_from_host`.
-///
 pub fn write_bytes<T>(
     caller: &mut Caller<'_, T>,
     memory: &Memory,

--- a/engine/src/runtime/helpers.rs
+++ b/engine/src/runtime/helpers.rs
@@ -37,20 +37,22 @@ pub fn get_func_from_caller<T>(
     caller: &mut Caller<'_, T>,
     export_name: &str,
 ) -> Result<wasmtime::Func, ()> {
-    match caller.get_export(export_name) {
-        Some(Extern::Func(f)) => Ok(f),
-        _ => Err(()),
-    }
+    let Some(Extern::Func(f)) = caller.get_export(export_name) else {
+        return Err(());
+    };
+
+    Ok(f)
 }
 
 ///
 /// Returns a handle to the guest environment's Memory object.
 ///
 pub fn get_memory_from_caller<T>(caller: &mut Caller<'_, T>) -> Result<Memory, ()> {
-    match caller.get_export("memory") {
-        Some(Extern::Memory(mem)) => Ok(mem),
-        _ => Err(()),
-    }
+    let Some(Extern::Memory(mem)) = caller.get_export("memory") else {
+        return Err(());
+    };
+
+    Ok(mem)
 }
 
 ///

--- a/engine/src/runtime/helpers.rs
+++ b/engine/src/runtime/helpers.rs
@@ -1,0 +1,99 @@
+use std::mem::size_of;
+
+use anyhow::anyhow;
+use wasmtime::{Caller, Extern, Memory, Val};
+
+///
+/// Calls into the guest environment to allocate a chunk of memory of the given size. if the guest
+/// does not expose a compatible alloc function, this will fail, and data exchange with the guest
+/// will not be possible. Our SDK automatically provides guest apps with this function.
+///
+pub fn alloc<T>(
+    caller: &mut Caller<'_, T>,
+    num_bytes_required: usize,
+) -> Result<usize, anyhow::Error> {
+    let Ok(alloc) = get_func_from_caller(caller, "alloc") else {
+        return Err(anyhow!("Failed to get alloc function from guest"));
+    };
+
+    // Note: We're casting an unsigned usize into an i32, which means we're losing
+    // half of our value range in wasm32. This shouldn't be a problem in practice,
+    // but I am calling it out here since it's not ideal. We can switch to using an
+    // I64 if it ever turns out to be a problem.
+    let params: Vec<Val> = vec![Val::I32(num_bytes_required as i32)];
+    let mut results: Vec<Val> = vec![Val::I32(0)];
+
+    alloc.call(caller, &params, &mut results)?;
+    let wasmtime::Val::I32(ptr) = results[0] else {
+        return Err(anyhow!("Alloc call failed"));
+    };
+    Ok(ptr as usize)
+}
+
+///
+/// Returns a handle to the exported guest function with the given name, or an error if none exists.
+///
+pub fn get_func_from_caller<T>(
+    caller: &mut Caller<'_, T>,
+    export_name: &str,
+) -> Result<wasmtime::Func, ()> {
+    match caller.get_export(export_name) {
+        Some(Extern::Func(f)) => Ok(f),
+        _ => Err(()),
+    }
+}
+
+///
+/// Returns a handle to the guest environment's Memory object.
+///
+pub fn get_memory_from_caller<T>(caller: &mut Caller<'_, T>) -> Result<Memory, ()> {
+    match caller.get_export("memory") {
+        Some(Extern::Memory(mem)) => Ok(mem),
+        _ => Err(()),
+    }
+}
+
+///
+/// Reads `len` bytes of data from the guest's memory starting at `ptr`.
+///
+pub fn read_bytes<T>(
+    caller: &Caller<'_, T>,
+    memory: Memory,
+    ptr: u32,
+    len: u32,
+) -> Result<Vec<u8>, anyhow::Error> {
+    let mut buf: Vec<u8> = vec![0; len as usize];
+    if let Err(err) = memory.read(caller, ptr.to_owned() as usize, &mut buf) {
+        eprintln!("Memory access error: {err:?}");
+        return Err(anyhow!(err));
+    };
+    Ok(buf)
+}
+
+///
+/// Writes the given data into the guest's memory, prefixed with a u32 indicating how many bytes of
+/// data were written. That is, if we want write the bytes [10, 20, 30, 40], this function will
+/// actually allocate 8 bytes total: 4 bytes for a u32 indicating the length of the data, followed by
+/// the 4 bytes of data itself. So, the value returned by this function would point to a chunk of
+/// memory containing the byte sequence [4, 0, 0, 0, 10, 20, 30, 40].
+/// A peer function to this one (to go from a pointer in shared memory to a Vec<u8> containing data)
+/// exists in the SDK as `get_bytes_from_host`.
+///
+pub fn write_bytes<T>(
+    caller: &mut Caller<'_, T>,
+    memory: &Memory,
+    bytes: Vec<u8>,
+) -> Result<usize, anyhow::Error> {
+    // Allocate enough memory to write a u32 + the contents of `bytes`. We'll write
+    // the length of bytes as a u32 at the start of the memory range, followed by
+    // the contents of `bytes`.
+    let num_bytes_required = size_of::<u32>() + bytes.len();
+    let ptr = alloc(caller, num_bytes_required)?;
+
+    // Now, copy the data over
+    let len_bytes = Vec::from((bytes.len() as u32).to_le_bytes());
+    let out_buffer = [len_bytes, bytes].concat();
+    memory.write(caller, ptr, &out_buffer)?;
+
+    Ok(ptr)
+}

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -1,0 +1,44 @@
+use wasi_common::WasiCtx;
+use wasmtime::{Caller, Linker};
+
+use crate::runtime::helpers::{get_memory_from_caller, read_bytes, write_bytes};
+
+mod helpers;
+
+///
+/// Registers all of our Serval-specific functions with the given Linker instance.
+///
+pub fn register_exports(linker: &mut Linker<WasiCtx>) -> Result<(), anyhow::Error> {
+    // The first parameter to func_wrap is the name of the import namespace and the second is the
+    // name of the function. The default namespace for WASM imports is "env". For example, this:
+    // ```
+    // linker.func_wrap("env", "add", |a: i32, b: i32| -> i32 { a + b })?;
+    // ```
+    // will define a function at `env::add`, which you can access in your WASM job under the name
+    // "add" with the following extern block:
+    // ```
+    // extern "C" { fn add(a: i32, b: i32) -> i32; }
+    // ```
+    // If you'd like your function to be under a different namespace, define it like this...
+    // ```
+    // linker.func_wrap("foo", "add", |a: i32, b: i32| -> i32 { a + b })?;
+    // ```
+    // ...and import like this:
+    // ```
+    // #[link(wasm_import_module = "foo")]
+    // extern "C" { fn add(a: i32, b: i32) -> i32; }
+    // ```
+    linker.func_wrap("serval", "add", add)?;
+
+    // TODO: load custom capabilities and expose them, exact details TBD
+
+    Ok(())
+}
+
+///
+/// This solely exists to have a trivial function in the serval namespace that samples can easily
+/// call to verify that things are working properly.
+///
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}


### PR DESCRIPTION
This branch starts to lay the groundwork for our SDK by doing two things:

1. It sets up a module structure to contain the functions we want to expose to guests running on a Serval agent. Previously, this was just a closure in ServalEngine that exposed a simple "add two numbers" function. Now it is it's own module, along with some helpers for exchanging data between the host and guest environments.
2. It implements _most of_ what we need to let jobs [invoke capabilities](https://www.notion.so/srvl/Jobs-brain-dump-a3078a047c6944959f193afca74c6d17#06af4a7a95f04957b3d5fb3737c20b75). I plan on actually implementing a capability (and the mechanisms required to load it off disk) as my next project.

You can [find the SDK here](https://github.com/servals/sdk), as well as [a sample job that uses it here](https://github.com/servals/wasm-samples/tree/main/sdk-test).

## Data exchange
One of the trickiest parts of working with WASM is data exchange between host and guest. Until the WebAssembly Component Model is a thing, we're limited to just passing around numbers and making use of our shared access to a flat plane of linear memory. In order to exchange data, both the host and the guest have to expose some functionality to each other. How we do it depends on which direction the data is going from:

- guest → host data exchange works by having the host accept both a pointer to some data as well as a length of how many bytes of data we're receiving. The `read_bytes` helper introduced in this PR handles this case; given a reference to a `Memory` instance, an offset, and a length, it will give us a `Vec<u8>`. Easy.
- host → guest exchange is, surprisingly, the more complex of the two. Only the guest can allocate memory, so we require the guest to export an `alloc` function ([this is part of the SDK](https://github.com/servals/sdk/blob/main/src/lib.rs#L53), so most of our users won't have to think about it). When the host wants to give some data back to the guest, it calls the `alloc` function, writes the data into the location that alloc returns, and returns a pointer to that data to the guest. Since we can't also return the length of the data, though, we have to write a little header before the data: a `u32` indicating how many bytes of data there are, followed by said data. This detail is abstracted away by the SDK's [get_bytes_from_host](https://github.com/servals/sdk/blob/main/src/lib.rs#L87) function, which takes a pointer, reads a u32 from that location telling it how many bytes to read, reads that many bytes immediately following the u32, and returns a `Vec<u8>`. Oh, and it deallocs the memory before it finishes, too.

## A note on `u32`s
Right now, all of this stuff is using `u32`s to pass data around, which makes sense to me given that we're using wasm32-wasi for all of our samples. I think I should probably switch things over to an `i64`, though, for two reasons:

1. Might as well be 64-bit friendly so we don't have to think about this ever again. Having an 8 byte header for data sent from host to guest, rather than 4 byte header, is a bit of extra overhead, but since we do a `dealloc` to clean it up as soon as we receive it, the additional overhead is not really a big deal.
2. Using signed rather than unsigned would give us a bit of signaling capacity for error propagation; right now we interpret a pointer of `0` as an error condition, but have no information about what went wrong.