### PR TITLE
agent - when using a randomly-selected port number, keep trying if binding fails

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
     let mut port: u16;
     let server: Server<_, _> = loop {
         port = predefined_port.unwrap_or_else(|| find_nearest_port(8100).unwrap());
-        let addr: SocketAddr = format!("{}:{}", host, port).parse().unwrap();
+        let addr: SocketAddr = format!("{host}:{port}").parse().unwrap();
         match axum::Server::try_bind(&addr) {
             Ok(builder) => break builder.serve(app.into_make_service()),
             Err(_) => {

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -52,8 +52,8 @@ impl JobMetadata {
             id,
             name,
             description,
-            status_url: format!("/v1/jobs/{}/status", id),
-            result_url: format!("/v1/jobs/{}/result", id),
+            status_url: format!("/v1/jobs/{id}/status"),
+            result_url: format!("/v1/jobs/{id}/result"),
         }
     }
 
@@ -73,8 +73,8 @@ impl From<Envelope> for JobMetadata {
             id,
             name: envelope.name.clone(),
             description: envelope.description,
-            status_url: format!("/jobs/{}/status", id),
-            result_url: format!("/jobs/{}/result", id),
+            status_url: format!("/jobs/{id}/status"),
+            result_url: format!("/jobs/{id}/result"),
         }
     }
 }

--- a/queue/src/api/mod.rs
+++ b/queue/src/api/mod.rs
@@ -25,7 +25,7 @@ pub async fn init_http(host: &str, port: u16, job_queue_filename: PathBuf) -> an
         .route("/jobs/:job_id/complete", post(v1::complete))
         .with_state(state);
 
-    let addr = format!("{}:{}", host, port);
+    let addr = format!("{host}:{port}");
     log::info!("Job queue service about to listen on http://{addr}");
     let addr: SocketAddr = addr.parse()?;
     match axum::Server::bind(&addr)

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -31,7 +31,7 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
 /// Find the nearest free port to the starting point.
 pub fn find_nearest_port(base_port: u16) -> Result<u16, ServalError> {
     for port in base_port..=u16::MAX {
-        if TcpListener::bind(format!("0.0.0.0:{}", port)).is_ok() {
+        if TcpListener::bind(format!("0.0.0.0:{port}")).is_ok() {
             return Ok(port);
         }
     }


### PR DESCRIPTION
This should solve our "address in use" race condition when spinning up several agents in rapid succession.