### PR TITLE
Use i32 rather than u32 for guest/host interop

### DIFF
--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -44,6 +44,11 @@ fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
+const INVOKE_CAPABILITY_ERROR_FAILED_TO_GET_MEMORY: i32 = -1;
+const INVOKE_CAPABILITY_ERROR_FAILED_TO_READ_CAPABILITY_NAME: i32 = -2;
+const INVOKE_CAPABILITY_ERROR_FAILED_TO_READ_DATA: i32 = -3;
+const INVOKE_CAPABILITY_ERROR_FAILED_TO_WRITE_RESPONSE: i32 = -4;
+
 ///
 /// Invokes the capability with the given name, passing along the given data payload and returning
 /// the response from the capability.
@@ -54,24 +59,24 @@ fn invoke_capability<T>(
     capability_name_len: u32,
     data_ptr: u32, // can point to anything at all
     data_len: u32,
-) -> u32 {
+) -> i32 {
     let Ok(memory) = get_memory_from_caller(&mut caller) else {
-        return 0;
+        return INVOKE_CAPABILITY_ERROR_FAILED_TO_GET_MEMORY;
     };
     let Ok(buf) = read_bytes(&caller, memory, capability_name_ptr, capability_name_len) else {
         eprintln!("Failed to read from capability_name_len");
-        return 0;
+        return INVOKE_CAPABILITY_ERROR_FAILED_TO_READ_CAPABILITY_NAME;
     };
     let capability_name = String::from_utf8_lossy(&buf);
     let Ok(data) = read_bytes(&caller, memory, data_ptr, data_len) else {
         eprintln!("Failed to read from data_ptr");
-        return 0;
+        return INVOKE_CAPABILITY_ERROR_FAILED_TO_READ_DATA;
     };
 
     let response = format!("Hello there! I can see that you tried to call the {capability_name} capability with {} bytes of data (to wit: {data:?}). Capabilities are not actually implemented yet, but this message did come from the host environment, so that's worth something, right?", data.len());
     let Ok(ptr) = write_bytes(&mut caller, &memory, response.as_bytes().to_vec()) else {
-        return 0;
+        return INVOKE_CAPABILITY_ERROR_FAILED_TO_WRITE_RESPONSE;
     };
 
-    ptr as u32
+    ptr as i32
 }

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -5,9 +5,7 @@ use crate::runtime::helpers::{get_memory_from_caller, read_bytes, write_bytes};
 
 mod helpers;
 
-///
 /// Registers all of our Serval-specific functions with the given Linker instance.
-///
 pub fn register_exports(linker: &mut Linker<WasiCtx>) -> Result<(), anyhow::Error> {
     // The first parameter to func_wrap is the name of the import namespace and the second is the
     // name of the function. The default namespace for WASM imports is "env". For example, this:
@@ -36,10 +34,8 @@ pub fn register_exports(linker: &mut Linker<WasiCtx>) -> Result<(), anyhow::Erro
     Ok(())
 }
 
-///
 /// This solely exists to have a trivial function in the serval namespace that samples can easily
 /// call to verify that things are working properly.
-///
 fn add(a: i32, b: i32) -> i32 {
     a + b
 }
@@ -49,10 +45,8 @@ const INVOKE_CAPABILITY_ERROR_FAILED_TO_READ_CAPABILITY_NAME: i32 = -2;
 const INVOKE_CAPABILITY_ERROR_FAILED_TO_READ_DATA: i32 = -3;
 const INVOKE_CAPABILITY_ERROR_FAILED_TO_WRITE_RESPONSE: i32 = -4;
 
-///
 /// Invokes the capability with the given name, passing along the given data payload and returning
 /// the response from the capability.
-///
 fn invoke_capability<T>(
     mut caller: Caller<'_, T>,
     capability_name_ptr: u32, // should point to UTF-8 string data


### PR DESCRIPTION
I went down the rabbit hole of converting everything to use i64, rather than u32, in anticipation of 64-bit WASM workloads, but I decided to back that out since AFAIK no one is actually building anything with 64-bit WASM right now—and at the very least, I certainly am not, and making speculative code changes is never a great idea. That work lived and died over in #32.

This branch has a much smaller scope: it switches `invoke_capability` from using an u32 to an i32, which gives us the ability to signal different error conditions with different negative values. Easy.