### PR TITLE
SDK name changes and support for WASM extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ name = "engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "log",
  "utils",
  "wasi-common",
  "wasmtime",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -12,7 +12,7 @@ engine = { path = "../engine" }
 env_logger.workspace = true
 http = "0.2.8"
 hyper = "0.14.23"
-log = "0.4.17"
+log.workspace = true
 mdns-sd.workspace = true
 reqwest.workspace = true
 serde = { version = "1.0.149", features = ["serde_derive"] }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow.workspace = true
+log.workspace = true
 utils = { path = "../utils" }
 wasi-common.workspace = true
 wasmtime.workspace = true

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -70,6 +70,8 @@ impl ServalEngine {
         let required_modules = module
             .imports()
             .map(|import| import.module().to_string())
+            // Everything that uses WASI is going to try to import wasi_snapshot_preview_1; that's
+            // provided by wasmtime_wasi for us.
             .filter(|import| !import.starts_with("wasi_snapshot_"));
         let required_modules: HashSet<String> = HashSet::from_iter(required_modules);
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -83,8 +83,8 @@ impl ServalEngine {
                 log::warn!("Extension {ext_name} is not available on this node");
                 continue;
             };
-            let cap_module = Module::from_binary(&self.engine, &fs::read(filename)?[..])?;
-            if let Err(err) = self.linker.module(&mut store, &ext_name, &cap_module) {
+            let ext_module = Module::from_binary(&self.engine, &fs::read(filename)?[..])?;
+            if let Err(err) = self.linker.module(&mut store, &ext_name, &ext_module) {
                 let filename = filename.to_string_lossy();
                 log::warn!("Error when trying to load extension {ext_name} from {filename}: {err}")
             };

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -29,8 +29,6 @@ pub fn register_exports(linker: &mut Linker<WasiCtx>) -> Result<(), anyhow::Erro
     linker.func_wrap("serval", "add", add)?;
     linker.func_wrap("serval", "invoke_raw", invoke_raw)?;
 
-    // TODO: load custom extensions and expose them, exact details TBD
-
     Ok(())
 }
 

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -9,6 +9,7 @@
 /// I am just a simple worker staying busy with one WebAssembly program at a time.
 use clap::Parser;
 use owo_colors::OwoColorize;
+use std::collections::HashMap;
 use std::path::Path;
 use std::{ffi::OsStr, fs};
 
@@ -59,7 +60,7 @@ fn main() -> anyhow::Result<()> {
     // [3]: https://petermalmgren.com/serverside-wasm-data/
 
     eprintln!("\n{} {}", "executing:".blue().bold(), exec_path.display());
-    let mut engine = ServalEngine::new()?;
+    let mut engine = ServalEngine::new(HashMap::new())?;
     let result = engine.execute(&binary, &stdin)?;
     eprintln!("{} {}", "exit status:".blue().bold(), result.code);
     eprintln!("\n{}:", "stdout".yellow().bold());


### PR DESCRIPTION
The small news here is renaming “capabilities” to “extensions” per our [discussion in Slack](https://serval.slack.com/archives/C04BKH1J31S/p1675098898015979?thread_ts=1674764493.574109&cid=C04BKH1J31S). 🥱 

The big news here is support for WASM extensions. If you start the agent up with an `EXTENSIONS_PATH` environment variable set, it will enumerate all of the .wasm files in that directory and make them available as imports to all jobs that run on this node. Once we have the job queue implemented, nodes should send a list of all of their extensions to the job claim endpoint, manifests should include a list of extensions they require, and the job queue should only send jobs to nodes that have all of the required extensions.

What happens if a job requires something that doesn't exist? Well, for now, it just tries to run it anyway, which will fail, but I figure this is fine for now—perhaps some jobs will be smart enough to conditionally use imports if they're available, but degrade gracefully.

## Future considerations

- We can statically analyze WASM binaries to see which imports they're looking for, so the manifest thing might not end up being strictly required.
- We will eventually need to figure out a permission model for using extensions.

## Details
As an example, imagine this AssemblyScript file was compiled to `as-fib.wasm` extensions directory:

```ts
export function fib(n: i32): i32 {
  var a = 0, b = 1;
  if (n > 0) {
    while (--n) {
      let t = a + b;
      a = b;
      b = t;
    }
    return b;
  }
  return a;
}
```

Then, any job could import that function like this:

````rust
#[link(wasm_import_module = "as-fib")] // ← "as-fib" is the name of the .wasm file that should export this function
extern "C" {
    fn fib(n: i32) -> i32; // ← "fib" is the name of the exported function
}

fn main() {
    for i in 1..10 {
        println!("Fibonacci #{i} = {}", unsafe { fib(i) }); // ← calling into anything from extern requires an unsafe block
    }
}
````

## Try it yourself
The good news is that both of these files exist over in the wasm-samples repo — see [`as-fib.ts`](https://github.com/serval/wasm-samples/blob/main/assemblyscript/src/as-fib.ts) and [`sdk-test/src/main.rs`](https://github.com/serval/wasm-samples/blob/main/sdk-test/src/main.rs). If you check out a copy of that repo, you can try this for yourself.

First, build the assemblyscript artifacts:
````sh
just build assemblyscript
````

Then, start up the agent and point it at the wasm-samples repo's `build` directory

````sh
EXTENSIONS_PATH=../wasm-samples/build cargo run --bin serval-agent
````

You'll see something like this in the logs:
```
[2023-01-31T17:33:50Z INFO  serval_agent] Found 6 extensions at "../wasm-samples/build": ["loudify", "list-files", "as-hello", "as-fib", "sdk-test", "error-prone"]
```

Then, in another tab, run the sdk-test:

```sh
just build-and-run sdk-test
```

You'll see something like this:
```
Sending sdk-test.wasm (2,091,440 bytes for binary + payload) to serval agent...
----------
Calling a WASM extension...
Fibonacci #1 = 1
Fibonacci #2 = 1
Fibonacci #3 = 2
Fibonacci #4 = 3
Fibonacci #5 = 5
(...and so on)
```

