### PR TITLE
Introduce the concept of a WASM manifest; use cacache for local storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa",
+ "itoa 1.0.5",
  "matchit",
  "memchr",
  "mime",
@@ -250,6 +250,18 @@ checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -616,6 +628,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +730,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1049,7 +1099,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -1111,7 +1161,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1235,6 +1285,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1696,6 +1752,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettytable"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +1942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,7 +2033,7 @@ dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
- "itoa",
+ "itoa 1.0.5",
  "libc",
  "linux-raw-sys",
  "once_cell",
@@ -2071,7 +2147,7 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2101,7 +2177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2118,8 +2194,10 @@ dependencies = [
  "loggerv",
  "mdns-sd",
  "owo-colors",
+ "prettytable",
  "reqwest",
  "serde_json",
+ "term_grid",
  "tokio",
  "utils",
  "uuid",
@@ -2335,6 +2413,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "term_grid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c9eb7705cb3f0fd71d3955b23db6d372142ac139e8c473952c93bf3c3dc4b7"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -194,11 +203,32 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -229,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +277,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cacache"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca04cc9e986327c58c6a9b06326e76d7c93ae00d86e1602b87027cb31a68545"
+dependencies = [
+ "digest 0.10.6",
+ "either",
+ "futures",
+ "hex 0.4.3",
+ "memmap2",
+ "miette",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "sha2 0.10.6",
+ "ssri",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "walkdir",
+]
+
+[[package]]
 name = "cap-fs-ext"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,7 +310,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -265,7 +326,7 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
  "winx",
 ]
 
@@ -550,8 +611,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
  "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -560,7 +630,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
 ]
 
@@ -619,9 +689,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -674,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,7 +772,7 @@ checksum = "28c0190ff0bd3b28bfdd4d0cf9f92faa12880fb0b8ae2054723dd6c76a4efd42"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -753,13 +829,28 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25ca26b0001154679ce0901527330e6153b670d17ccd1f86bab4e45dfba1a74"
+checksum = "857cf27edcb26c2a36d84b2954019573d335bb289876113aceacacdca47a4fd4"
 dependencies = [
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -769,6 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -778,10 +870,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -801,8 +915,11 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -817,6 +934,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -881,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -902,6 +1028,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
@@ -948,6 +1080,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -1025,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b24dd0826eee92c56edcda7ff190f2cf52115c49eadb2c2da8063e2673a8c2"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1050,22 +1191,22 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87bc110777311d7832025f38c4ab0f089f764644009edef3b5cbadfedee8c40"
+checksum = "d79107d6e60d78351e11f0a2dc9d0eaf304a7efb592e92603783afb8479c7d97"
 dependencies = [
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1083,7 +1224,7 @@ dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1132,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1156,6 +1297,12 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1242,6 +1389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1413,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd9b301defa984bbdbe112b4763e093ed191750a0d914a78c1106b2d0fe703"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c2401ab7ac5282ca5c8b518a87635b1a93762b0b90b9990c509888eeccba29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1284,7 +1463,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1324,6 +1503,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1538,12 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
@@ -1420,15 +1614,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1492,7 +1686,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1767,7 +1961,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1795,12 +1989,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1883,6 +2086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,13 +2113,13 @@ dependencies = [
  "anyhow",
  "atty",
  "clap",
+ "humansize",
  "log",
  "loggerv",
  "mdns-sd",
  "owo-colors",
  "reqwest",
  "serde_json",
- "thousands",
  "tokio",
  "utils",
  "uuid",
@@ -1936,6 +2148,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,7 +2190,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2011,6 +2258,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssri"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9cec0d388f39fbe79d7aa600e8d38053bf97b1bc8d350da7c0ba800d0f423f2"
+dependencies = [
+ "base64 0.10.1",
+ "digest 0.8.1",
+ "hex 0.3.2",
+ "serde",
+ "sha-1",
+ "sha2 0.8.2",
+ "thiserror",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-interface"
@@ -2051,7 +2313,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
  "winx",
 ]
 
@@ -2091,7 +2353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2134,12 +2396,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
@@ -2199,7 +2455,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2224,6 +2480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2511,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -2403,26 +2704,29 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "hex",
+ "cacache",
+ "hex 0.4.3",
  "if-addrs 0.8.0",
  "log",
  "mdns-sd",
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
+ "ssri",
  "thiserror",
  "tokio",
  "tokio-util",
+ "toml 0.7.1",
  "uuid",
  "wasi-common",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "rand",
@@ -2432,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bc89f2894593e665241e0052c3791999e6787b7c4831daa0a5c2e637e276d8"
+checksum = "c1b300a878652a387d2a0de915bdae8f1a548f0c6d45e072fe2688794b656cc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2452,6 +2756,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2490,7 +2805,7 @@ dependencies = [
  "system-interface",
  "tracing",
  "wasi-common",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2509,14 +2824,14 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wiggle",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2524,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -2539,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2551,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2561,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2574,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
@@ -2626,7 +2941,7 @@ dependencies = [
  "wasmtime-jit",
  "wasmtime-runtime",
  "wat",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2652,9 +2967,9 @@ dependencies = [
  "log",
  "rustix",
  "serde",
- "sha2",
- "toml",
- "windows-sys",
+ "sha2 0.10.6",
+ "toml 0.5.11",
+ "windows-sys 0.42.0",
  "zstd",
 ]
 
@@ -2728,7 +3043,7 @@ dependencies = [
  "cfg-if",
  "rustix",
  "wasmtime-asm-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2753,7 +3068,7 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2775,7 +3090,7 @@ checksum = "08fcba5ebd96da2a9f0747ab6337fe9788adfb3f63fa2c180520d665562d257e"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2800,7 +3115,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2871,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2987,6 +3302,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,13 +3378,13 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9baf690e238840de84bbfad6ad72d6628c41d34c1a5e276dab7fb2c9167ca1ac"
+checksum = "5bdaa56ed83ae727e40236218955924a676426a690b61b133102f8390b60aec8"
 dependencies = [
  "bitflags",
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ uuid = { version = "1.2.2", features = ["serde", "v4"] }
 wasi-common = "5.0.0"
 wasmtime = "5.0.0"
 wasmtime-wasi = "5.0.0"
+

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2021"
 license = "BSD-2-Clause-Patent"
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true }
 axum = { version = "0.6.1", features = ["json", "multipart"] }
 dotenvy = "0.15.6"
 engine = { path = "../engine" }
-env_logger.workspace = true
+env_logger = { workspace = true }
 http = "0.2.8"
 hyper = "0.14.23"
-log.workspace = true
-mdns-sd.workspace = true
-reqwest.workspace = true
+log = "0.4.17"
+mdns-sd = { workspace = true }
+reqwest = { workspace = true }
 serde = { version = "1.0.149", features = ["serde_derive"] }
-serde_json.workspace = true
-tokio.workspace = true
-tokio-util.workspace = true
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
 utils = { path = "../utils" }
-uuid.workspace = true
+uuid = { workspace = true }

--- a/agent/src/api/v1/jobs.rs
+++ b/agent/src/api/v1/jobs.rs
@@ -33,14 +33,14 @@ pub async fn run_job(
         return (StatusCode::NOT_FOUND, "no manifest of that name found").into_response();
     };
 
-    let Ok(executable) = storage.executable_as_bytes(&name, &manifest.version()).await else {
+    let Ok(executable) = storage.executable_as_bytes(&name, manifest.version()).await else {
         return (StatusCode::NOT_FOUND, "no executable found for manifest; key={key}").into_response();
     };
 
     let job = Job::new(manifest, executable, input.to_vec());
     log::info!(
         "received WASM job; name={}; executable length={}; input length={}; id={}",
-        &job.manifest().name(),
+        &job.manifest().fq_name(),
         &job.executable().len(),
         input.len(),
         job.id()

--- a/agent/src/api/v1/jobs.rs
+++ b/agent/src/api/v1/jobs.rs
@@ -1,82 +1,55 @@
-use std::{collections::HashMap, path::PathBuf};
-
-use anyhow::Result;
 use axum::{
-    extract::{Multipart, Path, State},
+    body::Bytes,
+    extract::{Path, State},
     http::StatusCode,
-    response::{IntoResponse, Response},
+    response::IntoResponse,
     Json,
 };
 use engine::{errors::ServalEngineError, ServalEngine};
-use utils::structs::WasmResult;
+use utils::structs::Job;
 
 use crate::structures::*;
 
-/// This is the main worker endpoint. It accepts incoming jobs and runs them.
-pub async fn incoming(state: State<AppState>, mut multipart: Multipart) -> Response {
-    let mut envelope: Option<Envelope> = None;
-    let mut binary: Option<Vec<u8>> = None;
-    let mut input: Option<Vec<u8>> = None;
-
-    // chomp up form input here
-    while let Some(field) = multipart.next_field().await.unwrap() {
-        let name = field.name().unwrap().to_string();
-        let data = field.bytes().await.unwrap();
-        match name.as_str() {
-            "envelope" => {
-                let data = data.to_vec();
-                let Ok(parsed) = serde_json::from_slice(&data) else {
-                    // this is not good enough
-                    return (StatusCode::BAD_REQUEST, "job envelope is invalid".to_string()).into_response();
-                };
-                envelope = Some(parsed);
-            }
-            "input" => {
-                input = Some(data.to_vec());
-            }
-            "executable" => {
-                binary = Some(data.to_vec());
-            }
-            _ => {
-                log::info!("ignoring unknown field `{name}`");
-            }
-        }
-    }
-
-    let Some(binary) = binary else {
-        return (
-            StatusCode::BAD_REQUEST,
-            "no wasm executable data provided!".to_string(),
-        )
-            .into_response();
-    };
-
-    let envelope = envelope.unwrap_or_default();
-    let metadata: JobMetadata = JobMetadata::from(envelope);
-    log::info!(
-        "received WASM job; name={}; executable length={}; input length={}",
-        metadata.name(),
-        binary.len(),
-        input.as_ref().map(|input| input.len()).unwrap_or_else(|| 0),
-    );
-
-    run_job_inner(state, metadata, binary, input).await
+/// Report on runtime history
+pub async fn monitor_status(state: State<AppState>) -> Json<RunnerState> {
+    let state = state.lock().await;
+    Json(state.clone())
 }
 
-async fn run_job_inner(
+/// Get running jobs
+pub async fn running(_state: State<AppState>) -> impl IntoResponse {
+    StatusCode::NOT_IMPLEMENTED
+}
+
+/// This is the main worker endpoint. It accepts incoming jobs and runs them.
+pub async fn run_job(
+    Path(name): Path<String>,
     state: State<AppState>,
-    metadata: JobMetadata,
-    binary: Vec<u8>,
-    input: Option<Vec<u8>>,
-) -> Response {
-    let mut state = state.lock().await;
+    input: Bytes,
+) -> impl IntoResponse {
+    let mut lock = state.lock().await;
+    let storage = lock.storage.as_ref().unwrap();
+    let Ok(manifest) = storage.manifest(&name).await else {
+        return (StatusCode::NOT_FOUND, "no manifest of that name found").into_response();
+    };
+
+    let Ok(executable) = storage.executable_as_bytes(&name, &manifest.version()).await else {
+        return (StatusCode::NOT_FOUND, "no executable found for manifest; key={key}").into_response();
+    };
+
+    let job = Job::new(manifest, executable, input.to_vec());
+    log::info!(
+        "received WASM job; name={}; executable length={}; input length={}; id={}",
+        &job.manifest().name(),
+        &job.executable().len(),
+        input.len(),
+        job.id()
+    );
 
     // Poor human's history tracking here. We'll need to do better at some point.
     // E.g., handle overflows. That would be some nice uptime.
-    state.total += 1;
-    state
-        .jobs
-        .insert(metadata.id().to_string(), metadata.clone());
+    lock.total += 1;
+    lock.jobs.insert(job.id().to_string(), job.clone());
 
     let start = std::time::Instant::now();
 
@@ -85,17 +58,24 @@ async fn run_job_inner(
     // The correct response by design is a 202 Accepted plus the metadata object.
     // TODO: SER-38 - capture exit code for failed jobs
     log::info!(
-        "about to run job name={}; id={}; executable size={}",
-        metadata.name(),
-        metadata.id(),
-        binary.len()
+        "about to run job name=TODO; id={}; executable size={}",
+        job.id(),
+        job.executable().len()
     );
-    match execute_job(binary, input, &state.extensions).await {
+
+    let extensions = lock.extensions.clone();
+
+    let Ok(mut engine) = ServalEngine::new(extensions) else {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "unable to create wasm engine").into_response();
+    };
+    let result = engine.execute(job.executable(), job.input());
+
+    match result {
         Ok(result) => {
             // We're not doing anything with stderr here.
             log::info!(
                 "job completed; job={}; code={}; elapsed_ms={}",
-                metadata.id(),
+                job.id(),
                 result.code,
                 start.elapsed().as_millis()
             );
@@ -117,53 +97,8 @@ async fn run_job_inner(
             (StatusCode::OK, stderr).into_response()
         }
         Err(e) => {
-            state.errors += 1;
+            lock.errors += 1;
             (StatusCode::BAD_REQUEST, e.to_string()).into_response()
         }
     }
-}
-
-/// Run a job in the wasm engine.
-// Probably can vanish because there's only one caller.
-async fn execute_job(
-    executable: Vec<u8>,
-    input: Option<Vec<u8>>,
-    extensions: &HashMap<String, PathBuf>,
-) -> Result<WasmResult, ServalEngineError> {
-    let stdin = input.unwrap_or_default();
-
-    let mut engine = ServalEngine::new(extensions.clone())?;
-    let result = engine.execute(&executable, &stdin)?;
-
-    Ok(result)
-}
-
-/// Run a previously-stored job by address. Fast hack. Feel free to improve with an input feature.
-pub async fn run_stored_job(
-    state: State<AppState>,
-    Path(blob_addr): Path<String>,
-) -> impl IntoResponse {
-    let locked = state.lock().await;
-
-    let Some(storage) = locked.storage.as_ref() else {
-        // todo: in this case, we should proxy this request to another node that is advertising the serval_storage role
-        return (StatusCode::SERVICE_UNAVAILABLE, "Storage is not available").into_response();
-    };
-
-    let Ok(binary) = storage.get_bytes(&blob_addr).await else {
-        return (
-            StatusCode::NOT_FOUND,
-            format!("Blob {} not found", &blob_addr),
-        )
-            .into_response();
-    };
-
-    let metadata = JobMetadata::new(blob_addr.clone(), "stored binary".to_string());
-    drop(locked);
-    run_job_inner(state, metadata, binary, None).await
-}
-
-pub async fn monitor_history(state: State<AppState>) -> Json<RunnerState> {
-    let state = state.lock().await;
-    Json(state.clone())
 }

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -80,7 +80,7 @@ pub async fn store_executable(
         Ok(integrity) => {
             log::info!(
                 "Stored new executable; name={}@{}; executable_hash={}; size={}",
-                &manifest.name(),
+                manifest.fq_name(),
                 version,
                 integrity,
                 bytes.len()
@@ -127,12 +127,12 @@ pub async fn store_manifest(State(state): State<AppState>, body: String) -> impl
 
     match Manifest::from_string(&body) {
         Ok(manifest) => {
-            log::info!("storing manifest for job={}", manifest.name());
+            log::info!("storing manifest for job={}", manifest.fq_name());
             match storage.store_manifest(&manifest).await {
                 Ok(integrity) => {
                     log::info!(
                         "Stored new manifest; name={}; manifest_hash={}",
-                        &manifest.name(),
+                        manifest.fq_name(),
                         integrity.to_string(),
                     );
                     (StatusCode::CREATED, integrity.to_string()).into_response()

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -3,21 +3,24 @@ use axum::{
     extract::{Path, State},
     http::{header, StatusCode},
     response::IntoResponse,
+    Json,
 };
 
 use utils::errors::ServalError;
+use utils::structs::Manifest;
 
 use crate::structures::AppState;
 
-pub async fn get_blob(
-    Path(blob_addr): Path<String>,
+/// Fetch an executable by fully-qualified manifest name.
+pub async fn get_executable(
+    Path((name, version)): Path<(String, String)>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
     // Yeah, I don't like this.
     let state = state.lock().await;
     let storage = state.storage.as_ref().unwrap();
 
-    match storage.get_stream(&blob_addr).await {
+    match storage.executable_as_stream(&name, &version).await {
         Ok(stream) => {
             let body = StreamBody::new(stream);
             let headers = [(
@@ -25,42 +28,78 @@ pub async fn get_blob(
                 String::from("application/octet-stream"),
             )];
 
-            log::info!("Serving blob; addr={}", &blob_addr);
+            log::info!("Serving job binary; name={}", &name);
             (headers, body).into_response()
         }
         Err(e) => {
-            log::warn!("error reading blob; addr={}; error={}", blob_addr, e);
+            log::warn!("error reading job binary; name={}; error={}", name, e);
             e.into_response()
         }
     }
 }
 
-pub async fn store_blob(State(state): State<AppState>, body: Bytes) -> impl IntoResponse {
+/// Fetch task manifest by name. The manifest is returned as json.
+pub async fn get_manifest(
+    Path(name): Path<String>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
     // Yeah, I don't like this.
-    let state = state.lock().await;
-    let storage = state.storage.as_ref().unwrap();
+    let lock = state.lock().await;
+    let storage = lock.storage.as_ref().unwrap();
 
-    match storage.store(&body).await {
-        Ok((new, address)) => {
-            log::info!("Stored blob; addr={} size={}", &address, body.len());
-            if new {
-                (StatusCode::CREATED, address).into_response()
-            } else {
-                (StatusCode::OK, address).into_response()
-            }
+    match storage.manifest(&name).await {
+        Ok(v) => {
+            log::info!("Serving job manifest; name={}", &name);
+            let stringified = v.to_string();
+            let headers = [(header::CONTENT_TYPE, String::from("application/toml"))];
+            (headers, stringified).into_response()
         }
-        Err(_e) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            log::warn!("error reading job metadata; name={}; error={}", &name, e);
+            e.into_response()
+        }
     }
 }
 
-pub async fn has_blob(Path(blob_addr): Path<String>, State(state): State<AppState>) -> StatusCode {
+/// Store a job with its metadata.
+pub async fn store_executable(
+    State(state): State<AppState>,
+    Path((name, version)): Path<(String, String)>,
+    body: Bytes,
+) -> impl IntoResponse {
+    let lock = state.lock().await;
+    let storage = lock.storage.as_ref().unwrap();
+
+    let Ok(manifest) = storage.manifest(&name).await else {
+        return (StatusCode::NOT_FOUND, format!("no manifest of that name found; name={name}")).into_response();
+    };
+
+    let bytes = body.to_vec();
+
+    match storage.store_executable(&name, &version, &bytes).await {
+        Ok(integrity) => {
+            log::info!(
+                "Stored new executable; name={}@{}; executable_hash={}; size={}",
+                &manifest.name(),
+                version,
+                integrity,
+                bytes.len()
+            );
+            (StatusCode::CREATED, integrity).into_response()
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
+/// Returns true if this node has access to the given task type, specified by fully-qualified name.
+pub async fn has_manifest(Path(name): Path<String>, State(state): State<AppState>) -> StatusCode {
     // Yeah, I don't like this.
     let state = state.lock().await;
     let storage = state.storage.as_ref().unwrap();
 
-    match storage.has_blob(&blob_addr).await {
+    match storage.data_exists_by_key(&name).await {
         Ok(exists) => {
-            log::info!("Has blob?; exists={exists} addr={blob_addr}");
+            log::info!("Has manifest?; exists={exists} addr={name}");
             if exists {
                 StatusCode::OK
             } else {
@@ -69,5 +108,38 @@ pub async fn has_blob(Path(blob_addr): Path<String>, State(state): State<AppStat
         }
         Err(ServalError::BlobAddressInvalid(_)) => StatusCode::BAD_REQUEST,
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+pub async fn list_manifests(State(state): State<AppState>) -> impl IntoResponse {
+    let lock = state.lock().await;
+    let storage = lock.storage.as_ref().unwrap();
+
+    match storage.manifest_names() {
+        Ok(list) => (StatusCode::OK, Json(list)).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+pub async fn store_manifest(State(state): State<AppState>, body: String) -> impl IntoResponse {
+    let lock = state.lock().await;
+    let storage = lock.storage.as_ref().unwrap();
+
+    match Manifest::from_string(&body) {
+        Ok(manifest) => {
+            log::info!("storing manifest for job={}", manifest.name());
+            match storage.store_manifest(&manifest).await {
+                Ok(integrity) => {
+                    log::info!(
+                        "Stored new manifest; name={}; manifest_hash={}",
+                        &manifest.name(),
+                        integrity.to_string(),
+                    );
+                    (StatusCode::CREATED, integrity.to_string()).into_response()
+                }
+                Err(e) => e.into_response(),
+            }
+        }
+        Err(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
     }
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -76,14 +76,29 @@ async fn main() -> Result<()> {
     const MAX_BODY_SIZE_BYTES: usize = 100 * 1024 * 1024;
     let app = Router::new()
         .route("/monitor/ping", get(ping))
-        .route("/v1/monitor/history", get(v1::jobs::monitor_history))
-        .route("/v1/jobs", post(v1::jobs::incoming))
-        .route("/v1/run/:addr", get(v1::jobs::run_stored_job))
+        .route("/monitor/status", get(v1::jobs::monitor_status))
+        .route("/v1/jobs", get(v1::jobs::running)) // TODO
+        .route("/v1/jobs/:name/run", post(v1::jobs::run_job)) // has an input payload; TODO options (needs design)
         // begin optional endpoints; these requests will be pre-empted by our
         // proxy_unavailable_services middleware if they aren't implemented by this instance.
-        .route("/v1/storage/blobs", put(v1::storage::store_blob))
-        .route("/v1/storage/blobs/:addr", get(v1::storage::get_blob))
-        .route("/v1/storage/blobs/:addr", head(v1::storage::has_blob))
+        .route("/v1/storage/manifests", get(v1::storage::list_manifests))
+        .route("/v1/storage/manifests", post(v1::storage::store_manifest))
+        .route(
+            "/v1/storage/manifests/:name",
+            get(v1::storage::get_manifest),
+        )
+        .route(
+            "/v1/storage/manifests/:name",
+            head(v1::storage::has_manifest),
+        )
+        .route(
+            "/v1/storage/manifests/:name/executable/:version",
+            put(v1::storage::store_executable),
+        )
+        .route(
+            "/v1/storage/manifests/:name/executable/:version",
+            get(v1::storage::get_executable),
+        )
         // end optional endpoints
         .route_layer(middleware::from_fn_with_state(
             state.clone(),

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tokio::sync::Mutex;
-use utils::{blobs::BlobStore, errors::ServalError};
+use utils::{blobs::BlobStore, errors::ServalError, structs::Job};
 use uuid::Uuid;
 
 use std::fs;
@@ -14,7 +14,7 @@ pub struct RunnerState {
     pub instance_id: Uuid,
     pub extensions: HashMap<String, PathBuf>,
     pub storage: Option<BlobStore>,
-    pub jobs: HashMap<String, JobMetadata>,
+    pub jobs: HashMap<String, Job>,
     pub total: usize,
     pub errors: usize,
 }
@@ -62,61 +62,3 @@ impl RunnerState {
 }
 
 pub type AppState = Arc<Mutex<RunnerState>>;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JobMetadata {
-    id: Uuid,
-    name: String,
-    description: String,
-    status_url: String, // for the moment
-    result_url: String, // for the moment
-}
-
-impl JobMetadata {
-    pub fn new(name: String, description: String) -> Self {
-        let id = Uuid::new_v4();
-        Self {
-            id,
-            name,
-            description,
-            status_url: format!("/v1/jobs/{id}/status"),
-            result_url: format!("/v1/jobs/{id}/result"),
-        }
-    }
-
-    pub fn id(&self) -> &Uuid {
-        &self.id
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-}
-
-impl From<Envelope> for JobMetadata {
-    fn from(envelope: Envelope) -> Self {
-        let id = Uuid::new_v4();
-        Self {
-            id,
-            name: envelope.name.clone(),
-            description: envelope.description,
-            status_url: format!("/jobs/{id}/status"),
-            result_url: format!("/jobs/{id}/result"),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Envelope {
-    name: String,
-    description: String,
-}
-
-impl Default for Envelope {
-    fn default() -> Self {
-        Self {
-            name: "unknown".to_string(),
-            description: "unknown job description".to_string(),
-        }
-    }
-}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,8 +13,10 @@ log = { workspace = true }
 loggerv = "0.7.2"
 mdns-sd = { workspace = true }
 owo-colors = "3.5.0"
+prettytable = "0.10.0"
 reqwest = { version = "0.11.13", features = ["blocking", "brotli", "json", "multipart", "rustls"] }
 serde_json = { workspace = true }
+term_grid = "0.2.0"
 tokio = { workspace = true }
 utils = { path = "../utils" }
 uuid = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 license = "BSD-2-Clause-Patent"
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true }
 atty = "0.2.14"
 clap = { version = "3.2.23", features = ["derive", "wrap_help"] } # older version on purpose
-log.workspace = true
+humansize = "2.1.3"
+log = { workspace = true }
 loggerv = "0.7.2"
-mdns-sd.workspace = true
+mdns-sd = { workspace = true }
 owo-colors = "3.5.0"
 reqwest = { version = "0.11.13", features = ["blocking", "brotli", "json", "multipart", "rustls"] }
-serde_json.workspace = true
-thousands = "0.2.0"
-tokio.workspace = true
+serde_json = { workspace = true }
+tokio = { workspace = true }
 utils = { path = "../utils" }
-uuid.workspace = true
+uuid = { workspace = true }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -90,8 +91,14 @@ fn upload_manifest(manifest_path: PathBuf) -> Result<()> {
     println!("Reading manifest: {}", manifest_path.display());
     let manifest = Manifest::from_file(&manifest_path)?;
 
-    println!("Reading WASM executable:{}", manifest.binary().display());
-    let executable = read_file(manifest.binary().to_path_buf())?;
+    let mut wasmpath = manifest_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    wasmpath.push(manifest.binary());
+
+    println!("Reading WASM executable:{}", wasmpath.display());
+    let executable = read_file(wasmpath)?;
 
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(60))

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -129,7 +129,9 @@ fn upload_manifest(manifest_path: PathBuf) -> Result<()> {
         table.add_row(row!["WASM integrity:", wasm_integrity]);
         table.add_row(row![
             "To run:",
-            format!("cargo run -- run {}", manifest.fq_name()).bold().blue()
+            format!("cargo run -- run {}", manifest.fq_name())
+                .bold()
+                .blue()
         ]);
     } else {
         table.add_row(row!["Storing the WASM executable failed!"]);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,7 +136,7 @@ fn upload_manifest(manifest_path: PathBuf) -> Result<()> {
         table.add_row(row!["WASM integrity:", wasm_integrity]);
         table.add_row(row![
             "To run:",
-            format!("cargo run -- run {}", manifest.fq_name())
+            format!("cargo run -p serval -- run {}", manifest.fq_name())
                 .bold()
                 .blue()
         ]);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -129,7 +129,7 @@ fn upload_manifest(manifest_path: PathBuf) -> Result<()> {
         table.add_row(row!["WASM integrity:", wasm_integrity]);
         table.add_row(row![
             "To run:",
-            format!("cargo run -- {}", manifest.fq_name()).bold().blue()
+            format!("cargo run -- run {}", manifest.fq_name()).bold().blue()
         ]);
     } else {
         table.add_row(row!["Storing the WASM executable failed!"]);

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -7,10 +7,10 @@ license = "BSD-2-Clause-Patent"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true }
 log.workspace = true
 utils = { path = "../utils" }
 thiserror.workspace = true
-wasi-common.workspace = true
-wasmtime.workspace = true
-wasmtime-wasi.workspce = true
+wasi-common = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -8,9 +8,9 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow = { workspace = true }
-log.workspace = true
+log = { workspace = true }
 utils = { path = "../utils" }
-thiserror.workspace = true
+thiserror = { workspace = true }
 wasi-common = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -33,10 +33,14 @@ help:
     cargo clippy --fix --allow-dirty --allow-staged
     cargo fmt
 
-# Cargo install required tools like `nextest`
+# Install required linting/testing tools via cargo.
 @install-tools:
     cargo install cargo-nextest
     cargo install cargo-deny
+
+# Check for unused dependencies.
+check-unused:
+    cargo +nightly udeps --all
 
 # Everyone loves Lady Gaga, right?
 @dance:

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,18 +7,21 @@ license = "BSD-2-Clause-Patent"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow.workspace = true
-axum.workspace = true
+anyhow = { workspace = true }
+axum = { workspace = true }
+cacache = { version = "11.0.0", default-features = false, features = ["tokio-runtime"] }
 hex = "0.4.3"
 if-addrs = "0.8.0"
-log.workspace = true
-mdns-sd.workspace = true
+log = { workspace = true }
+mdns-sd = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
 sha2 = "0.10.6"
-thiserror.workspace = true
-tokio.workspace = true
-tokio-util.workspace = true
-uuid.workspace = true
-wasi-common.workspace = true
-reqwest.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+ssri = "7.0.0"
+thiserror = { workspace = true }
+tokio-util = { workspace = true }
+tokio = { workspace = true }
+toml = "0.7.0"
+uuid = { workspace = true }
+wasi-common = { workspace = true }

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -78,8 +78,6 @@ use axum::response::IntoResponse;
 impl IntoResponse for ServalError {
     fn into_response(self) -> axum::response::Response {
         let status = match &self {
-            ServalError::NoFreePorts(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            ServalError::MdnsError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ServalError::AbnormalWasmExit { result: _ } => {
                 // We probably shouldn't be responding with this error directly ever,
                 // but we provide an implementation just in case. The assumption here is
@@ -90,7 +88,6 @@ impl IntoResponse for ServalError {
             ServalError::BlobAddressNotFound(_) => StatusCode::NOT_FOUND,
             ServalError::IoError(_) => StatusCode::NOT_FOUND,
             ServalError::ServiceNotFound => StatusCode::NOT_FOUND,
-            ServalError::AnyhowError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             // Catch-all for anything we don't want to add specific status codes for.
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };

--- a/utils/src/structs.rs
+++ b/utils/src/structs.rs
@@ -1,3 +1,10 @@
+use std::{fmt::Display, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::ServalError;
+
 /// The results of running a WASM executable.
 #[derive(Debug)]
 pub struct WasmResult {
@@ -7,4 +14,130 @@ pub struct WasmResult {
     pub stdout: Vec<u8>,
     /// Whatever the WASM executable wrote to stderr.
     pub stderr: Vec<u8>,
+}
+
+/// WASM executable metadata, for human reasons.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Manifest {
+    /// Name fully qualified by namespace.
+    fq_name: String,
+    /// Human-readable name. Case-insensitive. May only contain alphanumerics + underscore.
+    name: String,
+    /// A semver-compatible version string. Semver not yet enforced.
+    version: String,
+    /// Path to a compiled WASM exectuable.
+    binary: PathBuf,
+    /// Human-readable description.
+    description: String,
+    /// Required extensions.
+    required_extensions: Vec<String>, // TODO: version info, etc etc
+}
+
+impl Manifest {
+    // TODO: just to get going
+    pub fn new(namespace: String, name: String, description: String) -> Self {
+        // TODO: strip and lowercase name
+        let fq_name = format!("{namespace}.{name}");
+        Self {
+            fq_name,
+            name,
+            description,
+            ..Default::default()
+        }
+    }
+
+    pub fn from_string(input: &str) -> Result<Self, ServalError> {
+        let manifest: Manifest = toml::from_str(input)?;
+        Ok(manifest)
+    }
+
+    pub fn from_file(path: &PathBuf) -> Result<Self, ServalError> {
+        let buf = std::fs::read_to_string(path)?;
+        let manifest: Manifest = toml::from_str(&buf)?;
+        Ok(manifest)
+    }
+
+    pub fn binary(&self) -> PathBuf {
+        self.binary.clone()
+    }
+
+    pub fn version(&self) -> String {
+        self.version.clone()
+    }
+
+    /// Get the fully-qualified-by-namespace name for this job type manifest.
+    pub fn name(&self) -> String {
+        self.fq_name.clone()
+    }
+
+    /// Given a name but no manifest, build a key.
+    pub fn make_manifest_key(name: &str) -> String {
+        format!("{name}.manifest.toml")
+    }
+
+    /// Get the storage key for this manifest.
+    pub fn manifest_key(&self) -> String {
+        Manifest::make_manifest_key(&self.fq_name)
+    }
+
+    /// Given a name and a version but no manifest, build an executable key.
+    pub fn make_executable_key(name: &str, version: &str) -> String {
+        format!("{name}.{version}.wasm")
+    }
+
+    /// Get the key for the executable pointed to by this manifest.
+    pub fn executable_key(&self) -> String {
+        Manifest::make_executable_key(&self.fq_name, &self.version)
+    }
+}
+
+impl Display for Manifest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match toml::to_string(self) {
+            Ok(v) => write!(f, "{v}"),
+            Err(e) => write!(f, "{e:?}"),
+        }
+    }
+}
+
+/// Metadata about a specific job instance.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Job {
+    /// The ID of this job.
+    id: Uuid,
+    /// Fully-qualified job manifest specification. E.g., "sh.serval.birdfeeder"
+    manifest: Manifest,
+    /// bytes for the wasm executable
+    executable: Vec<u8>,
+    /// Input data
+    input: Vec<u8>,
+    // TODO: might have version chosen to run here, plus run options; might also store the input
+}
+
+impl Job {
+    pub fn new(manifest: Manifest, executable: Vec<u8>, input: Vec<u8>) -> Self {
+        let id = Uuid::new_v4();
+        Self {
+            id,
+            manifest,
+            executable,
+            input,
+        }
+    }
+
+    pub fn id(&self) -> &Uuid {
+        &self.id
+    }
+
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    pub fn executable(&self) -> &Vec<u8> {
+        &self.executable
+    }
+
+    pub fn input(&self) -> &Vec<u8> {
+        &self.input
+    }
 }


### PR DESCRIPTION
This PR reworks the agent API and the cli to support a new concept of a "manifest". This is a toml specification of a WASM job type. It includes a name, a namespace, a path to a binary, and some human-readable descriptions.

Here's an example manifest:

```toml
name = "loudify"
namespace = "sh.serval"
binary = "../../wasm-samples/build/loudify.wasm"
version = "1"
description = "SHOUT SHOUT LET IT ALL OUT"
required_extensions = ["birdfeeder"]
```

Once a WASM manifest + executable has been stored in the system, you can execute that wasm using the
name in the manifest: `pounce run sh.serval.loudify inputfile.txt`

The local blob storage has been reimplemented to use the [cacache](https://lib.rs/crates/cacache)
crate. This is a content-adddressable store that *also* allows lookup of items by key. In our case
we store manifests with keys like `name.manifest.toml` and wasm executables with names like
`name.wasm`. Execution of jobs is now more indirect than it was, in that we look up the manifest by
name, and from that look up where the binary is by version. This indirection allows us to support
versioning more fully in the long term.

This PR also significantly reworks the agent API and changes the CLI to support this new API. The agent endpoints now look like this:

- `GET /monitor/ping`: cheap health check
- `POST /v1/jobs/:name/run`: body is interpreted as job input
- `GET /v1/storage/manifests`: fetch a list of manifests
- `POST /v1/storage/manifests`: store a new manifest
- `GET /v1/storage/manifests/:name`: get a manifest by name
- `HEAD /v1/storage/manifests/:name`: 404s if manifest not found
- `PUT /v1/storage/manifests/:name/executable/:version`: store a new wasm executable associated with the named task manifest
- `GET /v1/storage/manifests/:name/executable/:version`: get a wasm executable by manifest name & version
- `GET /v1/monitor/history`: very cheap run history; to be deleted
- `GET /v1/jobs`: list all running jobs; not implemented

Also, take a few minor updates to crates; revert change to the workspace syntax because it is making VSCode angry.
