### PR TITLE
Fix request proxying, introducing RUNNER_ROLE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ name = "engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cranelift-codegen-meta",
  "log",
  "thiserror",
  "utils",

--- a/agent/src/api/v1/proxy.rs
+++ b/agent/src/api/v1/proxy.rs
@@ -49,6 +49,8 @@ pub async fn proxy_unavailable_services(
 fn get_proxy_target_service(path: &str, state: &RunnerState) -> Option<String> {
     if path.starts_with("/v1/storage/") && state.storage.is_none() {
         return Some(String::from("_serval_storage"));
+    } else if path.starts_with("/v1/jobs/") && !state.should_run_jobs {
+        return Some(String::from("_serval_runner"));
     }
 
     None

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -165,7 +165,14 @@ async fn main() -> Result<()> {
             extensions.len(),
             extensions.keys(),
         );
+    }
+
+    if should_run_jobs {
+        // todo: actually start polling job queue for work to do
+        log::info!("job running enabled");
+        advertise_service("serval_runner", port, &instance_id, None)?;
     } else {
+        log::info!("job running not enabled (or not supported)");
     }
 
     server.await.unwrap();

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -96,10 +96,10 @@ async fn main() -> Result<()> {
     let app = Router::new()
         .route("/monitor/ping", get(ping))
         .route("/monitor/status", get(v1::jobs::monitor_status))
-        .route("/v1/jobs", get(v1::jobs::running)) // TODO
-        .route("/v1/jobs/:name/run", post(v1::jobs::run_job)) // has an input payload; TODO options (needs design)
         // begin optional endpoints; these requests will be pre-empted by our
         // proxy_unavailable_services middleware if they aren't implemented by this instance.
+        .route("/v1/jobs", get(v1::jobs::running)) // TODO
+        .route("/v1/jobs/:name/run", post(v1::jobs::run_job)) // has an input payload; TODO options (needs design)
         .route("/v1/storage/manifests", get(v1::storage::list_manifests))
         .route("/v1/storage/manifests", post(v1::storage::store_manifest))
         .route(

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -17,6 +17,7 @@ pub struct RunnerState {
     pub jobs: HashMap<String, Job>,
     pub total: usize,
     pub errors: usize,
+    pub should_run_jobs: bool,
 }
 
 impl RunnerState {
@@ -24,6 +25,7 @@ impl RunnerState {
         instance_id: Uuid,
         blob_path: Option<PathBuf>,
         extensions_path: Option<PathBuf>,
+        should_run_jobs: bool,
     ) -> Result<Self, ServalError> {
         let storage = match blob_path {
             Some(path) => Some(BlobStore::new(path)?),
@@ -57,6 +59,7 @@ impl RunnerState {
             total: 0,
             errors: 0,
             jobs: HashMap::new(),
+            should_run_jobs,
         })
     }
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow = { workspace = true }
+cranelift-codegen-meta = "0.92.0"
 log = { workspace = true }
 utils = { path = "../utils" }
 thiserror = { workspace = true }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use cranelift_codegen_meta::isa::Isa;
 use utils::structs::WasmResult;
 use wasi_common::{
     pipe::{ReadPipe, WritePipe},
@@ -164,6 +165,13 @@ impl ServalEngine {
         };
 
         Ok(result)
+    }
+
+    pub fn is_available() -> bool {
+        // The cranelift code generator that underpins wasmtime doesn't support every architecture
+        // under the sun; in particular, it doesn't support 32-bit ARM, which is a potentially
+        // viable target for the Serval agent in general.
+        Isa::from_arch(std::env::consts::ARCH).is_some()
     }
 }
 


### PR DESCRIPTION
First and most embarrassingly of all, this fixes `proxy_unavailable_services` to actually include the body of the outermost request when proxying to another node. I am not sure how I noticed that this wasn't working. 😮‍💨

Secondly, this introduces the ability to proxy requests in the `/v1/jobs/` namespace to nodes advertising the `_serval_runner` role.

Finally, this adds a `RUNNER_ROLE` environment variable that controls whether a given instance should run jobs or proxy them elsewhere. The default is "auto", which enables job running if and only if the current platform is supported by wasmtime's cranelift code generator. This is in support of an observation that @jkbecker made about his Raspberry Pi Zero, which is a 32-bit ARM machine and is not supported by cranelift.