### PR TITLE
Job permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,10 @@ dependencies = [
  "clap",
  "engine",
  "owo-colors",
+ "serde",
+ "serde_json",
+ "toml 0.7.3",
+ "utils",
  "wasi-common",
  "wasmtime-wasi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.11.13",  default-features = false, features = ["brotli"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.38"
+toml = "0.7.0"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["io"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/agent/src/api/v1/jobs.rs
+++ b/agent/src/api/v1/jobs.rs
@@ -66,8 +66,8 @@ async fn run_job(
     let job = Job::new(manifest, executable, input.to_vec());
     log::info!(
         "received WASM job; name={}; executable length={}; input length={}; id={}",
-        &job.manifest().fq_name(),
-        &job.executable().len(),
+        job.manifest().fq_name(),
+        job.executable().len(),
         input.len(),
         job.id()
     );
@@ -77,9 +77,9 @@ async fn run_job(
     // What we'll do later is accept this job for processing and send it to a thread or something.
     // But for now we do it right here, in our handler.
     // The correct response by design is a 202 Accepted plus the metadata object.
-    // TODO: SER-38 - capture exit code for failed jobs
     log::info!(
-        "about to run job name=TODO; id={}; executable size={}",
+        "about to run job name={}; id={}; executable size={}",
+        job.manifest().fq_name(),
         job.id(),
         job.executable().len()
     );

--- a/agent/src/api/v1/jobs.rs
+++ b/agent/src/api/v1/jobs.rs
@@ -89,7 +89,14 @@ async fn run_job(
     let Ok(mut engine) = ServalEngine::new(extensions) else {
         return (StatusCode::INTERNAL_SERVER_ERROR, "unable to create wasm engine").into_response();
     };
-    let result = engine.execute(job.executable(), job.input());
+
+    // todo: verify that the user who submitted the job is actually authorized for all of the
+    // permissions that are listed in the manifest. If not, return a 403 error.
+    let result = engine.execute(
+        job.executable(),
+        job.input(),
+        job.manifest().required_permissions(),
+    );
 
     match result {
         Ok(result) => {

--- a/engine/src/errors.rs
+++ b/engine/src/errors.rs
@@ -39,4 +39,10 @@ pub enum ServalEngineError {
 
     #[error("Error reading bytes from stdout pipe")]
     StandardOutputReadError(),
+
+    #[error("Host platform does not support a required feature")]
+    UnsupportedFeatureError,
+
+    #[error("Job does not have permission to use extension '{0}'")]
+    ExtensionPermissionDenied(String),
 }

--- a/engine/src/extensions.rs
+++ b/engine/src/extensions.rs
@@ -1,0 +1,49 @@
+use std::{fs, path::PathBuf};
+
+use wasmtime::{Engine, Module};
+
+use crate::errors::ServalEngineError;
+
+#[derive(Clone, Debug)]
+pub struct ServalExtension {
+    filename: PathBuf,
+    name: String,
+}
+
+impl ServalExtension {
+    pub fn new(filename: PathBuf) -> Self {
+        let name = {
+            let mut filename = filename.clone();
+            filename.set_extension("");
+            filename.file_name().unwrap().to_string_lossy().into()
+        };
+
+        ServalExtension { filename, name }
+    }
+
+    pub fn module_for_engine(&self, engine: &Engine) -> Result<Module, ServalEngineError> {
+        let bytes = &fs::read(&self.filename)?[..];
+        Module::from_binary(engine, bytes).map_err(ServalEngineError::ModuleLoadError)
+    }
+}
+
+pub fn load_extensions(path: &PathBuf) -> Result<HashMap<String, ServalExtension>, ServalError> {
+    // Read the contents of the directory at the given path and build a HashMap that maps
+    // from the module's name (the filename minus the .wasm extension) to its path on disk.
+
+    let extensions: HashMap<String, ServalExtension> = fs::read_dir(&path)?
+        .filter_map(|entry| {
+            entry.ok().and_then(|entry| {
+                let filename = entry.file_name();
+                let filename = filename.to_string_lossy();
+                if !filename.to_lowercase().ends_with(".wasm") {
+                    return None;
+                }
+                let module_name = &filename[0..filename.len() - ".wasm".len()];
+                Some((module_name.to_string(), ServalExtension::new(entry.path())))
+            })
+        })
+        .collect();
+
+    Ok(extensions)
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -94,8 +94,8 @@ impl ServalEngine {
             .filter(|import| !import.starts_with("wasi_snapshot_"))
             // Our SDK functions are exported under the serval namespace; this is set up in the
             // register_exports function that we call in our constructor, above.
-            .filter(|import| import != "serval");
-        let required_modules: HashSet<String> = HashSet::from_iter(required_modules);
+            .filter(|import| import != "serval")
+            .collect::<HashSet<String>>();
 
         log::info!("Job wants the following extensions: {required_modules:?}");
 

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -12,7 +12,7 @@ engine = { path = "../engine" }
 owo-colors = "3.5.0"
 serde.workspace = true
 serde_json.workspace = true
-toml = "0.7.3"
+toml.workspace = true
 utils = { path = "../utils" }
 wasi-common.workspace = true
 wasmtime-wasi.workspace = true

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -10,5 +10,9 @@ atty.workspace = true
 clap.workspace = true
 engine = { path = "../engine" }
 owo-colors = "3.5.0"
+serde.workspace = true
+serde_json.workspace = true
+toml = "0.7.3"
+utils = { path = "../utils" }
 wasi-common.workspace = true
 wasmtime-wasi.workspace = true

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -151,7 +151,7 @@ fn main() -> anyhow::Result<()> {
                 exit(1);
             }
             _ => {
-                eprintln!("error: {err:?}");
+                eprintln!("error: {err}");
                 exit(1);
             }
         },

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -35,16 +35,7 @@ fn main() -> anyhow::Result<()> {
     let args = CLIArgs::parse();
 
     let exec_path = Path::new(&args.exec_path);
-    let extension = exec_path.extension().and_then(OsStr::to_str);
-
-    // TODO: check if it is *actually* valid WebAssembly (rather than just a valid extension).
-    if extension != Some("wasm") {
-        println!(
-            "\t⚠️ {}: file extension should be `wasm` but is instead `{}`.",
-            "Warning".red(),
-            extension.unwrap_or_default().blue()
-        );
-    }
+    assert!(is_wasm_executable(exec_path));
     let binary = fs::read(exec_path)?;
 
     let stdin = if let Some(input_file) = args.input_path {
@@ -88,4 +79,21 @@ fn main() -> anyhow::Result<()> {
     println!("{}", String::from_utf8(result.stderr)?);
 
     Ok(())
+}
+
+fn is_wasm_executable(path: &Path) -> bool {
+    let extension = path.extension().and_then(OsStr::to_str);
+
+    // TODO: check if it is *actually* valid WebAssembly (rather than just a valid extension).
+    if extension == Some("wasm") {
+        return true;
+    }
+
+    eprintln!(
+        "\t⚠️ {}: file extension should be `wasm` but is instead `{}`.",
+        "Warning".red(),
+        extension.unwrap_or_default().blue()
+    );
+
+    false
 }

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 use owo_colors::OwoColorize;
 use std::collections::HashMap;
 use std::io::{stdin, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{ffi::OsStr, fs};
 
 use engine::ServalEngine;
@@ -24,11 +24,12 @@ struct CLIArgs {
     // TODO: Check for the WASM binary magic bytes [1] or even evaluate file grammar [2].
     // [1]: Example: https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#the_simplest_module
     // [2]: Specification: https://webassembly.github.io/spec/core/index.html
-    exec_path: String,
+    exec_path: PathBuf,
     /// Optional path to a file containing input for the executable
     // Naive initial approach: We don't check file content and assume the executable knows what to do with it.
     // TODO: How would we validate that an input file is "correct" without running the job and seeing if it fails? TBD.
-    input_path: Option<String>,
+    #[clap(long)]
+    input_path: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -22,6 +22,6 @@ ssri = "8.0.0"
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
 tokio = { workspace = true }
-toml = "0.7.0"
+toml = { workspace = true }
 uuid = { workspace = true }
 wasi-common = { workspace = true }

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -70,6 +70,9 @@ pub enum ServalError {
     /// Translation for errors from ssri.
     #[error("ssri::Error: {0}")]
     SsriError(#[from] ssri::Error),
+
+    #[error("Manifest with a relative binary path was passed to Manifest::from_string; only absolute paths are supported here")]
+    RelativeBinaryPathInManifestError,
 }
 
 use axum::http::StatusCode;

--- a/utils/src/structs.rs
+++ b/utils/src/structs.rs
@@ -30,7 +30,12 @@ pub struct Manifest {
     /// Human-readable description.
     description: String,
     /// Required extensions.
-    required_extensions: Vec<String>, // TODO: this is a placeholder
+    required_extensions: Vec<String>,
+    // TODO: this is a placeholder and requires more thought; the WASM binary itself contains the
+    // info we need to enumerate the required extensions it is looking for. However, for job
+    // routing, it would be great for this information to be available without having the binary
+    // on-hand locally. The right answer here is probably to make this field be optional in manifest
+    // files, and to derive the value automatically at binary/manifest storage time.
     /// Required permissions; it is up to the agent to ensure that the submitter of this job is
     /// actually authorized to run a job with said permissions.
     required_permissions: Vec<Permission>,

--- a/utils/src/structs.rs
+++ b/utils/src/structs.rs
@@ -173,6 +173,20 @@ pub enum Permission {
     HttpHost(String),
 }
 
+impl Display for Permission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Permission::ProcRead => String::from("proc:read"),
+            Permission::AllExtensions => String::from("extension:*"),
+            Permission::Extension(name) => format!("extension:{name}"),
+            Permission::AllHttpHosts => String::from("http:*"),
+            Permission::HttpHost(host) => format!("http:{host}"),
+        };
+        let _ = write!(f, "{}", str);
+        Ok(())
+    }
+}
+
 impl FromStr for Permission {
     type Err = ();
 
@@ -214,13 +228,6 @@ impl Serialize for Permission {
     where
         S: Serializer,
     {
-        let str = match self {
-            Permission::ProcRead => String::from("proc:read:*"),
-            Permission::AllExtensions => String::from("extension:*"),
-            Permission::Extension(name) => format!("extension:{name}"),
-            Permission::AllHttpHosts => String::from("http:*"),
-            Permission::HttpHost(host) => format!("http:{host}"),
-        };
-        serializer.serialize_str(&str)
+        serializer.serialize_str(&self.to_string())
     }
 }


### PR DESCRIPTION
## What
This implements permission checks for jobs. I wanted to represent these in a nice format in the manifest files, so I ended up having to write my own serializing/deserializing code, which ended up taking up a lot more time than I expected. Alas. I think the format is pleasant:

- `proc:read:*` — whether they are allowed to read `/proc`; presumably a `proc:write:*` will make sense someday. Implementing more granular paths is an exercise for the future; my current thinking is that we'll have e.g. `proc:read:foo` to give access to `/proc/foo`, but maybe that's weird and we'll end up with a separate mechanism for giving access to various filesystem paths. Who knows!
- `extension:foo` — permission to use the extension `foo`
- `extension:*` — permission to use any extension
- `http:example.com` — permission to make HTTP requests to example.com
- 'http:*' — permission to make HTTP requests to any domain (unclear whether this should even exist as a feature, but it's useful for now)

These permissions can be placed in manifest files under `required_permissions`, and can be overridden when the test-runner via the `--permissions foo,bar,baz` parameter.

I also spruced up the extension loading code a bit, creating a `ServalExtension` struct to handle some of the file system shenanigans.