### PR TITLE
Switch from mdns to using the kaboodle peer mesh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayvec"
@@ -95,13 +95,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes 1.4.0",
  "futures-util",
  "http",
@@ -193,10 +193,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "block-buffer"
@@ -251,6 +276,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cacache"
@@ -280,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e05646ca0c0d3628153d93c91675b8aeebba6c07363ec4f2dd05f42a4648ba"
+checksum = "07d9cd7dc1d714d59974a6a68bed489c914b7b2620d1d4334d88d5ec9f29ebbd"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -292,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140f0d0d968143f4d23cd2958ccae53e3b336d7362920af268205b8593718933"
+checksum = "8e41334d53bab60f94878253f8a950c231596c8bbb99b4f71b13223dd48e18c6"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -309,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138311adb9c01710d0fac361da7bf646672e5df00e2f3283764b315449d6edeb"
+checksum = "6b5ddc7e3565e7cc4bf20d0c386b328f9e0f1b83fe0bcc0e055a1f08245e2aca"
 dependencies = [
  "ambient-authority",
  "rand",
@@ -319,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2139a25a1568af991f921198c13d30e5ddfacd06967707841905366aee257e0a"
+checksum = "e9dd840c16dee1df417f3985d173a2bb6ef55d48ea3d4deddcef46f31c9e7028"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -332,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711dddaae4b4cec2d0e729182fc4c27566f4945ea55ee7b852ce632b6ce7fe6"
+checksum = "77c39790e8e7455a92993bea5a2e947721c395cfbc344b74f092746c55441d76"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -364,15 +392,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
- "clap_derive",
- "clap_lex",
+ "bitflags 1.3.2",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "terminal_size",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+dependencies = [
+ "bitflags 2.0.2",
+ "clap_derive 4.1.9",
+ "clap_lex 0.3.3",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -385,7 +428,20 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -393,6 +449,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -921,7 +986,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1235,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -1252,9 +1317,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1313,6 +1378,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kaboodle"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542979ce171703f5b533d8c912373274bb8372cee7bfda612297d2eb9bfe5be2"
+dependencies = [
+ "anyhow",
+ "bincode 1.3.3",
+ "bytes 1.4.0",
+ "clap 4.1.11",
+ "crc32fast",
+ "dotenvy",
+ "env_logger",
+ "if-addrs 0.10.1",
+ "libc",
+ "log",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_derive",
+ "socket2",
+ "thiserror",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -1502,7 +1592,7 @@ checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1525,14 +1615,14 @@ checksum = "2a07ad93a80d1b92bb44cb42d7c49b49c9aab1778befefad49cceb5e4c5bf460"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -1637,11 +1727,11 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.46"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1658,7 +1748,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1669,9 +1759,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.81"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
  "autocfg",
  "cc",
@@ -1682,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "owo-colors"
@@ -1754,7 +1844,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1788,7 +1878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -1832,7 +1922,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1896,7 +1986,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1924,7 +2014,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -1935,7 +2025,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "clap",
+ "clap 3.2.23",
  "dotenvy",
  "env_logger",
  "log",
@@ -2015,7 +2105,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2070,9 +2160,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "async-compression",
  "base64 0.21.0",
@@ -2137,11 +2227,11 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "itoa",
@@ -2224,7 +2314,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2243,22 +2333,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2308,7 +2398,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "clap",
+ "clap 3.2.23",
  "humansize",
  "log",
  "loggerv",
@@ -2486,6 +2576,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +2598,7 @@ version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f355df185d945435f24c51fda9bf01bea6acb6c0b753e1241e5cc05413a659d4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -2571,7 +2672,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "clap",
+ "clap 3.2.23",
  "engine",
  "owo-colors",
  "serde",
@@ -2593,22 +2694,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2691,7 +2792,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2832,7 +2933,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2867,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -2926,10 +3027,13 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
+ "bincode 2.0.0-rc.2",
  "cacache",
  "hex",
  "if-addrs 0.10.1",
+ "kaboodle",
  "log",
  "mdns-sd",
  "reqwest",
@@ -2965,7 +3069,7 @@ checksum = "c1b300a878652a387d2a0de915bdae8f1a548f0c6d45e072fe2688794b656cc9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2979,6 +3083,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
 
 [[package]]
 name = "walkdir"
@@ -3037,7 +3147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46604ebe82881f99d88095c171eb84ae078c6b2a13f8f8f20ec00da60c8f6faf"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "cap-rand",
  "cap-std",
  "io-extras",
@@ -3101,7 +3211,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3135,7 +3245,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3186,7 +3296,7 @@ checksum = "49ffcc607adc9da024e87ca814592d4bc67f5c5b58e488f5608d5734a1ebc23e"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
+ "bincode 1.3.3",
  "cfg-if",
  "indexmap",
  "libc",
@@ -3227,7 +3337,7 @@ checksum = "c6b1611b04c29f2c4a434f109f6143a0719cb8b558370371d1bae7643aa173af"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
- "bincode",
+ "bincode 1.3.3",
  "directories-next",
  "file-per-thread-logger",
  "log",
@@ -3247,7 +3357,7 @@ checksum = "db5c3d25a7d531582fbaa75ce6a86dddc8211c783cb247af053075a0fcc9d3d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -3320,7 +3430,7 @@ checksum = "90ba5779ea786386432b94c9fc9ad5597346c319e8239db0d98d5be5cc109a7e"
 dependencies = [
  "addr2line",
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "cfg-if",
  "cpp_demangle",
  "gimli",
@@ -3498,7 +3608,7 @@ checksum = "4edae96a8cef2aaf1d2ce42a41814ee1a0fb55c5171de6b6166bd2d6fa2f5b7b"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 1.3.2",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -3516,7 +3626,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn",
+ "syn 1.0.109",
  "witx",
 ]
 
@@ -3528,7 +3638,7 @@ checksum = "f4fd7c907d4640faf42369832a583304476aa0178cb7481c5772c0495effa8b2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wiggle-generate",
 ]
 
@@ -3668,7 +3778,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129cd8ee937d535e1a239d9d3c9c0525af0454bc0967d9211a251be062513520"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "io-lifetimes",
  "windows-sys 0.45.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,6 @@ dependencies = [
  "humansize",
  "log",
  "loggerv",
- "mdns-sd",
  "owo-colors",
  "prettytable",
  "reqwest",
@@ -2425,7 +2424,6 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "mdns-sd",
  "metrics",
  "metrics-exporter-log",
  "metrics-exporter-tcp",
@@ -2563,6 +2561,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "syn"
@@ -3041,6 +3061,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "ssri",
+ "strum",
  "thiserror",
  "tokio 1.26.0",
  "tokio-util",

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 [![Main branch checks](https://github.com/serval/serval-mesh/actions/workflows/main.yaml/badge.svg)](https://github.com/serval/serval-mesh/actions/workflows/main.yaml)
 
-This monorepo contains the source for the various components of the Serval mesh, intended to run on any host where you want to run WASM payloads. As of December 2022, this project is in very early stages of development and is changing rapidly.
+This monorepo contains the source for the various components of the Serval mesh, intended to run on any host where you want to run Wasm payloads. As of December 2022, this project is in very early stages of development and is changing rapidly.
 
 The repo is a Rust workspace containing the following members:
 
 - `agent`: a daemon that listens on a port for incoming HTTP requests with payloads to run
-- `cli`: a command-line interface (called `serval` when built) for controlling the mesh and creating WASM jobs
+- `cli`: a command-line interface (called `serval` when built) for controlling the mesh and creating Wasm jobs
 - `engine`: a library for the [wasmtime](https://lib.rs/crates/wasmtime) glue; in early stages
 - `queue`: temporarily a separate service during MVP/demo period, this is manages the job queue for the Serval mesh. This functionality will eventually be integrated into the Serval agent.
 - `utils`: a library for code we use in several places
-- `test-runner`: a CLI to execute a WASM payload once, useful for developing the engine
+- `test-runner`: a CLI to execute a Wasm payload once, useful for developing the engine
 
 ## Local development
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -13,7 +13,6 @@ env_logger = { workspace = true }
 http = "0.2.8"
 hyper = "0.14.23"
 log = "0.4.17"
-mdns-sd = { workspace = true }
 metrics = "0.20.1"
 metrics-exporter-log = "0.4.0"
 metrics-exporter-tcp = "0.7.0"

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,6 +1,6 @@
 # Serval Agent
 
-The serval agent is a persistent process that advertises itself on the network as a runner for WASM jobs. It listens on HTTP for incoming job requests.
+The serval agent is a persistent process that advertises itself on the network as a runner for Wasm jobs. It listens on HTTP for incoming job requests.
 
 It is _not yet_ a full Serval agent node, because it does not make any attempt to find a control node and ask for jobs. Instead it listens passively to be pushed incoming workloads.
 
@@ -20,7 +20,7 @@ TODO; this should respond with a history of jobs and their statuses
 
 This endpoint is not likely to remain in its current state; it exists to allow any HTTP client to post a test job to the runner.
 
-This endpoint accepts an executable WASM job via multipart form data. The body must include two parts: a job metadata envelope in json format named `envelope`, and an octet-stream containing the WASM binary to run.
+This endpoint accepts an executable Wasm job via multipart form data. The body must include two parts: a job metadata envelope in json format named `envelope`, and an octet-stream containing the Wasm binary to run.
 
 Here is an OpenAPI schema definition for this request:
 

--- a/agent/src/api/v1/proxy.rs
+++ b/agent/src/api/v1/proxy.rs
@@ -7,12 +7,13 @@ use http::{
     header::{CONTENT_LENGTH, EXPECT, HOST},
     HeaderValue,
 };
-use mdns_sd::ServiceInfo;
 use utils::{
     errors::ServalError,
-    mdns::{discover_service, get_service_instance_id},
+    mesh::{KaboodlePeer, PeerMetadata},
 };
 use uuid::Uuid;
+
+use crate::structures::MESH;
 
 // Relay the given request to to the first node that we discover that is advertising the given
 // service. in the future, we may keep a list of known nodes for a given service so we can avoid
@@ -22,15 +23,16 @@ pub async fn relay_request(
     service_name: &str,
     source_instance_id: &Uuid,
 ) -> Result<Response, ServalError> {
-    let node_info = discover_service(service_name).await.map_err(|err| {
-        log::warn!("proxy_unavailable_services failed to find a node offering the service; service={service_name}; err={err:?}");
+    let mesh = MESH.get().expect("Peer network not initialized!");
+    let Some(peer) = mesh.find_role(&service_name.to_string()).await else {
+        log::warn!("proxy_unavailable_services failed to find a node offering the service; service={service_name}");
         metrics::increment_counter!("proxy:no_service");
-        err
-    })?;
+        return Err(ServalError::ServiceNotFound);
+    };
 
-    let result = proxy_request_to_other_node(req, &node_info, source_instance_id).await;
+    let result = proxy_request_to_other_node(req, &peer, source_instance_id).await;
     result.map_err(|err| {
-        log::warn!("Failed to proxy request to other node; node={node_info:?}; err={err:?}");
+        log::warn!("Failed to proxy request to peer; peer={peer:?}; err={err:?}");
         metrics::increment_counter!("proxy:failure");
         err
     })
@@ -38,19 +40,23 @@ pub async fn relay_request(
 
 async fn proxy_request_to_other_node(
     req: &mut Request<Body>,
-    info: &ServiceInfo,
+    peer: &PeerMetadata,
     source_instance_id: &Uuid,
 ) -> Result<Response, ServalError> {
-    let target_instance_id = get_service_instance_id(info)?;
-    let host = info.get_addresses().iter().next().unwrap(); // unwrap is safe because discover_service will never return a service without addresses
-    let port = info.get_port();
+    let target_instance_id = peer.name();
+    let Some(socket_addr) = peer.address() else {
+        log::warn!("got a peer without an address; peer={}", peer.name());
+        metrics::increment_counter!("proxy:failure");
+        return Err(ServalError::ServiceNotFound);
+    };
+
     let path = req.uri().path();
     let query = req
         .uri()
         .query()
         .map(|qs| format!("?{qs}"))
         .unwrap_or_else(|| "".to_string());
-    let url = format!("http://{host}:{port}{path}{query}");
+    let url = format!("http://{socket_addr}{path}{query}");
     let mut inner_req = reqwest::Client::new().request(req.method().clone(), url);
 
     // Copy over the headers, modulo a few that are only relevant to the original request
@@ -86,7 +92,7 @@ async fn proxy_request_to_other_node(
 
     resp.headers_mut().append(
         "Serval-Proxied-From",
-        HeaderValue::from_str(&target_instance_id.to_string()).map_err(anyhow::Error::from)?,
+        HeaderValue::from_str(target_instance_id).map_err(anyhow::Error::from)?,
     );
 
     Ok(resp)

--- a/agent/src/api/v1/proxy.rs
+++ b/agent/src/api/v1/proxy.rs
@@ -9,7 +9,7 @@ use http::{
 };
 use utils::{
     errors::ServalError,
-    mesh::{KaboodlePeer, PeerMetadata},
+    mesh::{KaboodlePeer, PeerMetadata, ServalRole},
 };
 use uuid::Uuid;
 
@@ -20,12 +20,12 @@ use crate::structures::MESH;
 // running the discovery process for every proxy request.
 pub async fn relay_request(
     req: &mut Request<Body>,
-    service_name: &str,
+    role: &ServalRole,
     source_instance_id: &Uuid,
 ) -> Result<Response, ServalError> {
     let mesh = MESH.get().expect("Peer network not initialized!");
-    let Some(peer) = mesh.find_role(&service_name.to_string()).await else {
-        log::warn!("proxy_unavailable_services failed to find a node offering the service; service={service_name}");
+    let Some(peer) = mesh.find_role(role).await else {
+        log::warn!("proxy_unavailable_services failed to find a node offering the service; service={role}");
         metrics::increment_counter!("proxy:no_service");
         return Err(ServalError::ServiceNotFound);
     };

--- a/agent/src/api/v1/proxy.rs
+++ b/agent/src/api/v1/proxy.rs
@@ -43,9 +43,9 @@ async fn proxy_request_to_other_node(
     peer: &PeerMetadata,
     source_instance_id: &Uuid,
 ) -> Result<Response, ServalError> {
-    let target_instance_id = peer.name();
+    let target_instance_id = peer.instance_id();
     let Some(socket_addr) = peer.address() else {
-        log::warn!("got a peer without an address; peer={}", peer.name());
+        log::warn!("got a peer without an address; peer={}", peer.instance_id());
         metrics::increment_counter!("proxy:failure");
         return Err(ServalError::ServiceNotFound);
     };

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -7,8 +7,8 @@ use axum::{
     Json,
 };
 
-use utils::errors::ServalError;
 use utils::structs::Manifest;
+use utils::{errors::ServalError, mesh::ServalRole};
 
 use crate::structures::*;
 
@@ -41,14 +41,14 @@ async fn proxy(State(state): State<AppState>, mut request: Request<Body>) -> imp
     log::info!("relaying a storage request; path={path}");
 
     if let Ok(resp) =
-        super::proxy::relay_request(&mut request, SERVAL_SERVICE_STORAGE, &state.instance_id).await
+        super::proxy::relay_request(&mut request, &ServalRole::Storage, &state.instance_id).await
     {
         resp
     } else {
         // Welp, not much we can do
         (
             StatusCode::SERVICE_UNAVAILABLE,
-            format!("{SERVAL_SERVICE_STORAGE} not available"),
+            "Peer with the storage role not available",
         )
             .into_response()
     }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -187,7 +187,12 @@ async fn main() -> Result<()> {
         Err(_) => 8181,
     };
 
-    let metadata = PeerMetadata::new(format!("{}:{}", host, port), roles, None);
+    let metadata = PeerMetadata::new(
+        Uuid::new_v4().to_string(),
+        format!("http://{}:{}", host, port),
+        roles,
+        None,
+    );
     let mut mesh = ServalMesh::new(metadata, mesh_port, None).await?;
     mesh.start().await?;
     MESH.set(mesh).unwrap();

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -171,17 +171,20 @@ async fn main() -> Result<()> {
     let mut roles: Vec<String> = Vec::new();
     if blob_path.is_some() {
         log::info!("serval agent blob store mounted; path={blob_path:?}");
-        roles.push("serval_storage".to_string());
+        roles.push(SERVAL_SERVICE_STORAGE.to_string());
     }
     if should_run_jobs {
         log::info!("job running enabled");
-        roles.push("serval_runner".to_string());
+        roles.push(SERVAL_SERVICE_RUNNER.to_string());
     } else {
         log::info!("job running not enabled (or not supported)");
     }
     let metadata = PeerMetadata::new("I have a name".to_string(), roles, None);
-    let mut agent = ServalMesh::new(metadata, port, None).await?;
-    agent.start().await?;
+    let mut mesh = ServalMesh::new(metadata, port, None).await?;
+    mesh.start().await?;
+    MESH.set(mesh).unwrap();
+
+    // And finally, listen on HTTP.
     server.await.unwrap();
     Ok(())
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -172,7 +172,10 @@ async fn main() -> Result<()> {
 
     let mut roles: Vec<ServalRole> = Vec::new();
     if let Some(storage_path) = blob_path {
-        log::info!("serval agent blob store mounted; path={}", storage_path.display());
+        log::info!(
+            "serval agent blob store mounted; path={}",
+            storage_path.display()
+        );
         roles.push(ServalRole::Storage);
     }
     if should_run_jobs {
@@ -190,12 +193,7 @@ async fn main() -> Result<()> {
     let host_ip = host.parse()?;
     let http_addr = SocketAddr::new(host_ip, port);
 
-    let metadata = PeerMetadata::new(
-        Uuid::new_v4().to_string(),
-        Some(http_addr),
-        roles,
-        None,
-    );
+    let metadata = PeerMetadata::new(Uuid::new_v4().to_string(), Some(http_addr), roles, None);
     let mut mesh = ServalMesh::new(metadata, mesh_port, None).await?;
     mesh.start().await?;
     MESH.set(mesh).unwrap();

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -8,9 +8,6 @@ use uuid::Uuid;
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
-pub static SERVAL_SERVICE_STORAGE: &str = "_serval_storage";
-pub static SERVAL_SERVICE_RUNNER: &str = "_serval_runner";
-
 pub static STORAGE: OnceCell<BlobStore> = OnceCell::new();
 pub static MESH: OnceCell<ServalMesh> = OnceCell::new();
 

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use engine::extensions::{load_extensions, ServalExtension};
 use once_cell::sync::OnceCell;
+use utils::mesh::ServalMesh;
 use utils::{blobs::BlobStore, errors::ServalError};
 use uuid::Uuid;
 
@@ -11,6 +12,7 @@ pub static SERVAL_SERVICE_STORAGE: &str = "_serval_storage";
 pub static SERVAL_SERVICE_RUNNER: &str = "_serval_runner";
 
 pub static STORAGE: OnceCell<BlobStore> = OnceCell::new();
+pub static MESH: OnceCell<ServalMesh> = OnceCell::new();
 
 pub type ServalRouter = axum::Router<Arc<RunnerState>, hyper::Body>;
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,6 @@ clap = { version = "3.2.23", features = ["derive", "wrap_help"] } # older versio
 humansize = "2.1.3"
 log = { workspace = true }
 loggerv = "0.7.2"
-mdns-sd = { workspace = true }
 owo-colors = "3.5.0"
 prettytable = "0.10.0"
 reqwest = { version = "0.11.13", default-features = false, features = ["blocking", "deflate", "brotli", "json", "multipart", "stream", "rustls-tls"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ log = { workspace = true }
 loggerv = "0.7.2"
 owo-colors = "3.5.0"
 prettytable = "0.10.0"
-reqwest = { version = "0.11.13", default-features = false, features = ["blocking", "deflate", "brotli", "json", "multipart", "stream", "rustls-tls"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["deflate", "brotli", "json", "multipart", "stream", "rustls-tls"] }
 serde_json = { workspace = true }
 term_grid = "0.2.0"
 tokio = { workspace = true }

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,6 +1,6 @@
 # Engine glue
 
-This is the library that implements our convenience layer around the embedded WASM engine.
+This is the library that implements our convenience layer around the embedded Wasm engine.
 
 ## design notes
 

--- a/engine/src/errors.rs
+++ b/engine/src/errors.rs
@@ -31,7 +31,7 @@ pub enum ServalEngineError {
     #[error("std::io::Error: {0}")]
     IoError(#[from] std::io::Error),
 
-    #[error("Failed to load WASM module")]
+    #[error("Failed to load Wasm module")]
     ModuleLoadError(anyhow::Error),
 
     #[error("Error reading bytes from stderr pipe")]

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -32,7 +32,7 @@ use wasi_experimental_http_wasmtime::{HttpCtx, HttpState};
 
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
-/// Make one of these to get a WASM runner with the Serval glue.
+/// Make one of these to get a Wasm runner with the Serval glue.
 pub struct ServalEngine {
     extensions: HashMap<String, ServalExtension>,
     engine: Engine,
@@ -67,7 +67,7 @@ impl ServalEngine {
         })
     }
 
-    /// Run the passed-in WASM executable on the given input bytes.
+    /// Run the passed-in Wasm executable on the given input bytes.
     pub fn execute(
         &mut self,
         // WebAssembly module to execute
@@ -134,7 +134,7 @@ impl ServalEngine {
         let module = Module::from_binary(&self.engine, wasm_module_bytes)
             .map_err(ServalEngineError::ModuleLoadError)?;
 
-        // Load any custom WASM node features that the job requires (...and that we have)
+        // Load any custom Wasm node features that the job requires (...and that we have)
         let required_modules = module
             .imports()
             .map(|import| import.module().to_string())
@@ -204,16 +204,16 @@ impl ServalEngine {
             .map_err(|_| ServalEngineError::StandardErrorReadError())?
             .into_inner();
 
-        // Here we run the WASM and trap any errors. We do not consider non-zero exit codes to be
-        // an error in *executing* the WASM, but instead to be information to be returned to the
+        // Here we run the Wasm and trap any errors. We do not consider non-zero exit codes to be
+        // an error in *executing* the Wasm, but instead to be information to be returned to the
         // caller.
         let code = match executed {
             Err(e) => {
                 if let Some(exit) = e.downcast_ref::<I32Exit>() {
                     exit.0
                 } else {
-                    // This is a genuine error from the WASM engine, not a non-zero exit code from the
-                    // the WASM executable.
+                    // This is a genuine error from the Wasm engine, not a non-zero exit code from the
+                    // the Wasm executable.
                     return Err(ServalEngineError::ExecutionError {
                         error: e,
                         stdout: outbytes,

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -8,11 +8,11 @@ mod helpers;
 /// Registers all of our Serval-specific functions with the given Linker instance.
 pub fn register_exports(linker: &mut Linker<WasiCtx>) -> Result<(), ()> {
     // The first parameter to func_wrap is the name of the import namespace and the second is the
-    // name of the function. The default namespace for WASM imports is "env". For example, this:
+    // name of the function. The default namespace for Wasm imports is "env". For example, this:
     // ```
     // linker.func_wrap("env", "add", |a: i32, b: i32| -> i32 { a + b })?;
     // ```
-    // will define a function at `env::add`, which you can access in your WASM job under the name
+    // will define a function at `env::add`, which you can access in your Wasm job under the name
     // "add" with the following extern block:
     // ```
     // extern "C" { fn add(a: i32, b: i32) -> i32; }

--- a/queue/README.md
+++ b/queue/README.md
@@ -61,7 +61,7 @@ Enqueues a new job, which will be created with the status of `pending`.
 
 Parameters:
 
-- `binary_addr`: a CAS address pointing to a WASM binary on the Storage Server
+- `binary_addr`: a CAS address pointing to a Wasm binary on the Storage Server
 - `input_addr`: optionally, a CAS address pointing to a blob on the Storage Server
 
 Example output:

--- a/test-runner/README.md
+++ b/test-runner/README.md
@@ -6,7 +6,7 @@ A wasm-automatic-iterative-travailleur. Simple-minded, entirely focused on crunc
 
 The current state of this code base is far from where it will eventually be. Right now, this
 
-* Is a simple command-line application that runs a WASM program provided to it
+* Is a simple command-line application that runs a Wasm program provided to it
 * Will perform some simple checks to test if the relevant files exist or not, but is not very thorough at it
 ## Issues
 
@@ -23,7 +23,7 @@ USAGE:
     test-runner <EXEC_PATH> [INPUT_PATH]
 
 ARGS:
-    <EXEC_PATH>     Path to the WASM executable to run
+    <EXEC_PATH>     Path to the Wasm executable to run
     <INPUT_PATH>    Optional path to a file containing input for the executable
 
 OPTIONS:
@@ -32,7 +32,7 @@ OPTIONS:
 
 ## Example
 
-This assumes the existence of a `.wasm` file and an input file with arbitrary content (but usable by the WASM executable).
+This assumes the existence of a `.wasm` file and an input file with arbitrary content (but usable by the Wasm executable).
 
 Compiling our [wasi-hello-world](https://github.com/serval/wasm-samples/tree/main/wasi-hello-world) example and creating a `testinput.txt` file with some text in it works for an initial quick & dirty test.
 

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -24,8 +24,8 @@ use engine::ServalEngine;
 /// The real worker will pick up executables and inputs from an API endpoint.
 #[derive(Parser, Debug)]
 struct CLIArgs {
-    /// Path to the WASM executable or Serval manifest to run
-    // TODO: Check for the WASM binary magic bytes [1] or even evaluate file grammar [2].
+    /// Path to the Wasm executable to run
+    // TODO: Check for the Wasm binary magic bytes [1] or even evaluate file grammar [2].
     // [1]: Example: https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#the_simplest_module
     // [2]: Specification: https://webassembly.github.io/spec/core/index.html
     exec_path: PathBuf,

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
 ssri = "8.0.0"
+strum = { version="0.24.1", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,20 +8,23 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = "0.1.67"
 axum = { workspace = true }
+bincode = "2.0.0-rc.2"
 cacache = { version = "11.0.0", default-features = false, features = ["tokio-runtime"] }
 hex = "0.4.3"
 if-addrs = "0.10.1"
+kaboodle = "0.1.2"
 log = { workspace = true }
 mdns-sd = { workspace = true }
 reqwest = { workspace = true }
-serde_json = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 sha2 = "0.10.6"
 ssri = "8.0.0"
 thiserror = { workspace = true }
-tokio-util = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 wasi-common = { workspace = true }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -2,5 +2,6 @@ pub mod blobs;
 pub mod errors;
 pub mod futures;
 pub mod mdns;
+pub mod mesh;
 pub mod networking;
 pub mod structs;

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -1,0 +1,113 @@
+use async_trait::async_trait;
+use bincode::{Decode, Encode};
+use if_addrs::Interface;
+use kaboodle::{errors::KaboodleError, Kaboodle};
+
+use std::net::SocketAddr;
+
+/// This type encodes the responsibilities of the resources we are meshing together.
+pub trait KaboodlePeer {
+    fn new(address: SocketAddr, identity: Vec<u8>) -> Self;
+    fn identity(&self) -> Vec<u8>;
+    fn name(&self) -> &str;
+    fn roles(&self) -> Vec<String>;
+}
+
+/// A little wrapper around kaboodle so we can hide the machinery of encoding and decoding.
+/// the identity payload.
+#[async_trait]
+pub trait KaboodleMesh {
+    type A;
+
+    /// Create a new entry for a Kaboodle peer network and add ourselves to the mesh.
+    async fn new(
+        name: &str,
+        roles: Vec<String>,
+        port: u16,
+        interface: Option<Interface>,
+    ) -> Result<Box<Self>, KaboodleError>;
+    /// Get a list of peers. It's the implementer's responsibility to decide if this is fresh or cached somehow.
+    async fn peers(&self) -> Vec<Self::A>;
+    /// Given a specific role, look for a peer that advertises the role.
+    async fn find_role(&self, role: &str) -> Result<Self::A, KaboodleError>;
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+struct VersionEnvelope {
+    version: u8,
+    rest: Vec<u8>
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+pub struct ServalPeer {
+    name: String,
+    roles: Vec<String>,
+}
+
+impl KaboodlePeer for ServalPeer {
+    fn new(address: SocketAddr, encoded: Vec<u8>) -> Self {
+        // TODO: this is actually fallible
+        let config = bincode::config::standard();
+        let (envelope, _len): (VersionEnvelope, usize) = bincode::decode_from_slice(&encoded[..], config).unwrap();
+        // In the future, switch on version in the envelope and decode into variants.
+        let (peer, _len): (Self, usize) = bincode::decode_from_slice(&envelope.rest[..], config).unwrap();
+        peer
+    }
+
+    fn identity(&self) -> Vec<u8> {
+        // TODO: this is actually fallible
+        let config = bincode::config::standard();
+        let rest: Vec<u8> = bincode::encode_to_vec(self, config).unwrap();
+        let envelope = VersionEnvelope { version: 1, rest };
+        let identity: Vec<u8> = bincode::encode_to_vec(envelope, config).unwrap();
+        identity
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn roles(&self) -> Vec<String> {
+        self.roles.clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct AgentMesh {
+    kaboodle: Kaboodle,
+    agent: ServalPeer,
+}
+
+#[async_trait]
+impl KaboodleMesh for AgentMesh {
+    type A = ServalPeer;
+
+    async fn new(
+        name: &str,
+        roles: Vec<String>,
+        port: u16,
+        interface: Option<Interface>,
+    ) -> Result<Box<Self>, KaboodleError> {
+        let agent = ServalPeer {
+            name: name.to_string(),
+            roles,
+        };
+        let identity = agent.identity();
+        let mut kaboodle = Kaboodle::new(port, interface, identity).unwrap();
+        kaboodle.start().await?;
+        Ok(Box::new(Self { kaboodle, agent }))
+    }
+
+    async fn peers(&self) -> Vec<Self::A> {
+        let peers = self.kaboodle.peers().await; // this isn't fallible? really? okay
+        peers.into_iter().map(|(addr, identity)| {
+            ServalPeer::new(addr, identity.to_vec())
+        }).collect()
+    }
+
+    async fn find_role(&self, role: &str) -> Result<Self::A, KaboodleError> {
+        let peers = self.peers().await;
+        // find somebody who matches our role
+        todo!();
+    }
+}

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 /// the identity payload.
 #[async_trait]
 pub trait KaboodleMesh {
-    type A;
+    type A: KaboodlePeer;
 
     /// Create a new entry for a Kaboodle peer network and add ourselves to the mesh.
     async fn start(&mut self) -> Result<(), KaboodleError>;

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -61,7 +61,7 @@ pub struct PeerMetadata {
 #[derive(Debug, Clone, Decode, Encode)]
 struct MetadataInner {
     instance_id: String,
-    http_address: String,
+    http_address: Option<SocketAddr>, // this is an option because CLIs don't have one
     roles: Vec<ServalRole>,
 }
 
@@ -69,7 +69,7 @@ impl PeerMetadata {
     /// Create a new metadata node from useful information.
     pub fn new(
         instance_id: String,
-        http_address: String,
+        http_address: Option<SocketAddr>,
         roles: Vec<ServalRole>,
         address: Option<SocketAddr>,
     ) -> Self {
@@ -92,8 +92,8 @@ impl PeerMetadata {
     }
 
     /// Get the advertised http address of this peer.
-    pub fn http_address(&self) -> &str {
-        &self.inner.http_address
+    pub fn http_address(&self) -> Option<SocketAddr> {
+        self.inner.http_address
     }
 }
 
@@ -149,12 +149,12 @@ impl ServalMesh {
     }
 
     /// Given a specific role, look for all peers that advertise the role.
-    pub async fn find_role(&self, role: &ServalRole) -> Vec<PeerMetadata> {
+    pub async fn peers_with_role(&self, role: &ServalRole) -> Vec<PeerMetadata> {
         let peers = self.peers().await;
         // A naive implementation, to understate the matter, but it gets us going.
         peers
             .into_iter()
-            .filter(|xs| xs.roles().contains(role))
+            .filter(|xs| xs.roles().contains(role) && xs.http_address().is_some())
             .collect()
     }
 }

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -5,14 +5,6 @@ use kaboodle::{errors::KaboodleError, Kaboodle};
 
 use std::net::SocketAddr;
 
-/// This type encodes the responsibilities of the resources we are meshing together.
-pub trait KaboodlePeer {
-    fn new(address: SocketAddr, identity: Vec<u8>) -> Self;
-    fn identity(&self) -> Vec<u8>;
-    fn name(&self) -> &str;
-    fn roles(&self) -> Vec<String>;
-}
-
 /// A little wrapper around kaboodle so we can hide the machinery of encoding and decoding.
 /// the identity payload.
 #[async_trait]
@@ -20,94 +12,129 @@ pub trait KaboodleMesh {
     type A;
 
     /// Create a new entry for a Kaboodle peer network and add ourselves to the mesh.
-    async fn new(
-        name: &str,
-        roles: Vec<String>,
-        port: u16,
-        interface: Option<Interface>,
-    ) -> Result<Box<Self>, KaboodleError>;
+    async fn start(&mut self) -> Result<(), KaboodleError>;
     /// Get a list of peers. It's the implementer's responsibility to decide if this is fresh or cached somehow.
     async fn peers(&self) -> Vec<Self::A>;
-    /// Given a specific role, look for a peer that advertises the role.
-    async fn find_role(&self, role: &str) -> Result<Self::A, KaboodleError>;
 }
 
+/// This type encodes the responsibilities of the resources we are meshing together.
+pub trait KaboodlePeer {
+    /// Create a new peer structure from the node identity payload plus an address.
+    fn from_identity(address: SocketAddr, encoded: Vec<u8>) -> Self;
+    /// Create an identity payload from whatever internal information matters to your implementation.
+    fn identity(&self) -> Vec<u8>;
+    /// Get the address of this node.
+    fn address(&self) -> Option<SocketAddr>;
+}
+
+// End of tiny wrapper around Kaboodle.
+
+// An envelope that holds a version number. A little bit of future-proofing
+// to allow agents with higher version numbers to decode payloads from older agents.
+// Possibly over-thinking it.
 #[derive(Debug, Clone, Decode, Encode)]
 struct VersionEnvelope {
     version: u8,
     rest: Vec<u8>
 }
 
-#[derive(Debug, Clone, Decode, Encode)]
-pub struct ServalPeer {
-    name: String,
-    roles: Vec<String>,
+#[derive(Debug, Clone)]
+pub struct PeerMetadata {
+    address: Option<SocketAddr>,
+    inner: MetadataInner,
 }
 
-impl KaboodlePeer for ServalPeer {
-    fn new(address: SocketAddr, encoded: Vec<u8>) -> Self {
-        // TODO: this is actually fallible
+// The ddta we need to encode our identity as a serval peer. Done with an additional
+// type to get the derive. There'll be another way to do this, I'm sure.
+#[derive(Debug, Clone, Decode, Encode)]
+struct MetadataInner {
+    name: String,
+    roles: Vec<String>
+}
+
+impl PeerMetadata {
+    pub fn new(name: String, roles: Vec<String>, address: Option<SocketAddr>) -> Self {
+        let inner = MetadataInner { name, roles };
+        Self {
+            address, inner
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    pub fn roles(&self) -> Vec<String> {
+        self.inner.roles.clone()
+    }
+}
+
+impl KaboodlePeer for PeerMetadata {
+    fn from_identity(address: SocketAddr, encoded: Vec<u8>) -> Self {
+        // TODO: this is actually fallible; when might it fail?
         let config = bincode::config::standard();
         let (envelope, _len): (VersionEnvelope, usize) = bincode::decode_from_slice(&encoded[..], config).unwrap();
         // In the future, switch on version in the envelope and decode into variants.
-        let (peer, _len): (Self, usize) = bincode::decode_from_slice(&envelope.rest[..], config).unwrap();
-        peer
+        let (inner, _len): (MetadataInner, usize) = bincode::decode_from_slice(&envelope.rest[..], config).unwrap();
+        PeerMetadata { address: Some(address), inner }
     }
 
     fn identity(&self) -> Vec<u8> {
-        // TODO: this is actually fallible
+        // TODO: this is actually fallible; when might it fail?
         let config = bincode::config::standard();
-        let rest: Vec<u8> = bincode::encode_to_vec(self, config).unwrap();
+        let rest: Vec<u8> = bincode::encode_to_vec(self.inner.clone(), config).unwrap();
         let envelope = VersionEnvelope { version: 1, rest };
         let identity: Vec<u8> = bincode::encode_to_vec(envelope, config).unwrap();
         identity
     }
 
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn roles(&self) -> Vec<String> {
-        self.roles.clone()
+    fn address(&self) -> Option<SocketAddr> {
+        self.address
     }
 }
 
+// End of peer implementation. Now we dive into the mesh itself.
+
 #[derive(Debug)]
-pub struct AgentMesh {
+pub struct ServalMesh {
     kaboodle: Kaboodle,
-    agent: ServalPeer,
+    metadata: PeerMetadata,
+}
+
+impl ServalMesh {
+    /// Create a new node and join it to the mesh.
+    pub async fn new(
+        metadata: PeerMetadata,
+        port: u16,
+        interface: Option<Interface>,
+    ) -> Result<Self, KaboodleError> {
+        let identity = metadata.identity();
+        let kaboodle = Kaboodle::new(port, interface, identity)?;
+        Ok(Self { kaboodle, metadata })
+    }
+
+    /// Given a specific role, look for a peer that advertises the role.
+    pub async fn find_role(&self, role: &String) -> Option<PeerMetadata> {
+        let peers = self.peers().await;
+        // A naive implementation, to understate the matter, but it gets us going.
+        peers.into_iter().find(|xs| {
+            xs.roles().contains(role)
+        })
+    }
 }
 
 #[async_trait]
-impl KaboodleMesh for AgentMesh {
-    type A = ServalPeer;
+impl KaboodleMesh for ServalMesh {
+    type A = PeerMetadata;
 
-    async fn new(
-        name: &str,
-        roles: Vec<String>,
-        port: u16,
-        interface: Option<Interface>,
-    ) -> Result<Box<Self>, KaboodleError> {
-        let agent = ServalPeer {
-            name: name.to_string(),
-            roles,
-        };
-        let identity = agent.identity();
-        let mut kaboodle = Kaboodle::new(port, interface, identity).unwrap();
-        kaboodle.start().await?;
-        Ok(Box::new(Self { kaboodle, agent }))
+    async fn start(&mut self) -> Result<(), KaboodleError> {
+        self.kaboodle.start().await
     }
 
     async fn peers(&self) -> Vec<Self::A> {
         let peers = self.kaboodle.peers().await; // this isn't fallible? really? okay
         peers.into_iter().map(|(addr, identity)| {
-            ServalPeer::new(addr, identity.to_vec())
+            PeerMetadata::from_identity(addr, identity.to_vec())
         }).collect()
-    }
-
-    async fn find_role(&self, role: &str) -> Result<Self::A, KaboodleError> {
-        let peers = self.peers().await;
-        // find somebody who matches our role
-        todo!();
     }
 }

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -48,20 +48,23 @@ pub struct PeerMetadata {
 // type to get the derive. There'll be another way to do this, I'm sure.
 #[derive(Debug, Clone, Decode, Encode)]
 struct MetadataInner {
-    name: String,
+    instance_id: String,
     roles: Vec<String>,
 }
 
 impl PeerMetadata {
-    pub fn new(name: String, roles: Vec<String>, address: Option<SocketAddr>) -> Self {
-        let inner = MetadataInner { name, roles };
+    /// Create a new metadata node from useful information.
+    pub fn new(instance_id: String, roles: Vec<String>, address: Option<SocketAddr>) -> Self {
+        let inner = MetadataInner { instance_id, roles };
         Self { address, inner }
     }
 
-    pub fn name(&self) -> &str {
-        &self.inner.name
+    /// Get the instance_id for this peer.
+    pub fn instance_id(&self) -> &str {
+        &self.inner.instance_id
     }
 
+    /// Get the roles this peer has chosen to advertise.
     pub fn roles(&self) -> Vec<String> {
         self.inner.roles.clone()
     }
@@ -101,11 +104,11 @@ impl KaboodlePeer for PeerMetadata {
 #[derive(Debug)]
 pub struct ServalMesh {
     kaboodle: Kaboodle,
-    metadata: PeerMetadata,
+    metadata: PeerMetadata,  // TODO: do I need this?
 }
 
 impl ServalMesh {
-    /// Create a new node and join it to the mesh.
+    /// Create a new node, with a kaboodle instance ready to run but not yet joined.
     pub async fn new(
         metadata: PeerMetadata,
         port: u16,
@@ -133,6 +136,7 @@ impl KaboodleMesh for ServalMesh {
     }
 
     async fn peers(&self) -> Vec<Self::A> {
+        // No caching or smarts at all in the initial implementation.
         let peers = self.kaboodle.peers().await; // this isn't fallible? really? okay
         peers
             .into_iter()

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -86,11 +86,10 @@ impl KaboodlePeer for PeerMetadata {
     }
 
     fn identity(&self) -> Vec<u8> {
-        // TODO: this is actually fallible; when might it fail?
         let config = bincode::config::standard();
-        let rest: Vec<u8> = bincode::encode_to_vec(self.inner.clone(), config).unwrap();
+        let rest: Vec<u8> = bincode::encode_to_vec(self.inner.clone(), config).unwrap_or_default();
         let envelope = VersionEnvelope { version: 1, rest };
-        let identity: Vec<u8> = bincode::encode_to_vec(envelope, config).unwrap();
+        let identity: Vec<u8> = bincode::encode_to_vec(envelope, config).unwrap_or_default();
         identity
     }
 
@@ -136,8 +135,7 @@ impl KaboodleMesh for ServalMesh {
     }
 
     async fn peers(&self) -> Vec<Self::A> {
-        // No caching or smarts at all in the initial implementation.
-        let peers = self.kaboodle.peers().await; // this isn't fallible? really? okay
+        let peers = self.kaboodle.peers().await;
         peers
             .into_iter()
             .map(|(addr, identity)| PeerMetadata::from_identity(addr, identity.to_vec()))

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -35,7 +35,7 @@ pub trait KaboodlePeer {
 #[derive(Debug, Clone, Decode, Encode)]
 struct VersionEnvelope {
     version: u8,
-    rest: Vec<u8>
+    rest: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -49,15 +49,13 @@ pub struct PeerMetadata {
 #[derive(Debug, Clone, Decode, Encode)]
 struct MetadataInner {
     name: String,
-    roles: Vec<String>
+    roles: Vec<String>,
 }
 
 impl PeerMetadata {
     pub fn new(name: String, roles: Vec<String>, address: Option<SocketAddr>) -> Self {
         let inner = MetadataInner { name, roles };
-        Self {
-            address, inner
-        }
+        Self { address, inner }
     }
 
     pub fn name(&self) -> &str {
@@ -73,10 +71,15 @@ impl KaboodlePeer for PeerMetadata {
     fn from_identity(address: SocketAddr, encoded: Vec<u8>) -> Self {
         // TODO: this is actually fallible; when might it fail?
         let config = bincode::config::standard();
-        let (envelope, _len): (VersionEnvelope, usize) = bincode::decode_from_slice(&encoded[..], config).unwrap();
+        let (envelope, _len): (VersionEnvelope, usize) =
+            bincode::decode_from_slice(&encoded[..], config).unwrap();
         // In the future, switch on version in the envelope and decode into variants.
-        let (inner, _len): (MetadataInner, usize) = bincode::decode_from_slice(&envelope.rest[..], config).unwrap();
-        PeerMetadata { address: Some(address), inner }
+        let (inner, _len): (MetadataInner, usize) =
+            bincode::decode_from_slice(&envelope.rest[..], config).unwrap();
+        PeerMetadata {
+            address: Some(address),
+            inner,
+        }
     }
 
     fn identity(&self) -> Vec<u8> {
@@ -117,9 +120,7 @@ impl ServalMesh {
     pub async fn find_role(&self, role: &String) -> Option<PeerMetadata> {
         let peers = self.peers().await;
         // A naive implementation, to understate the matter, but it gets us going.
-        peers.into_iter().find(|xs| {
-            xs.roles().contains(role)
-        })
+        peers.into_iter().find(|xs| xs.roles().contains(role))
     }
 }
 
@@ -133,8 +134,9 @@ impl KaboodleMesh for ServalMesh {
 
     async fn peers(&self) -> Vec<Self::A> {
         let peers = self.kaboodle.peers().await; // this isn't fallible? really? okay
-        peers.into_iter().map(|(addr, identity)| {
-            PeerMetadata::from_identity(addr, identity.to_vec())
-        }).collect()
+        peers
+            .into_iter()
+            .map(|(addr, identity)| PeerMetadata::from_identity(addr, identity.to_vec()))
+            .collect()
     }
 }

--- a/utils/src/structs.rs
+++ b/utils/src/structs.rs
@@ -5,27 +5,27 @@ use uuid::Uuid;
 
 use crate::errors::ServalError;
 
-/// The results of running a WASM executable.
+/// The results of running a Wasm executable.
 #[derive(Debug)]
 pub struct WasmResult {
     /// The status code returned by the execution; 0 for normal termination.
     pub code: i32,
-    /// Whatever the WASM executable wrote to stdout.
+    /// Whatever the Wasm executable wrote to stdout.
     pub stdout: Vec<u8>,
-    /// Whatever the WASM executable wrote to stderr.
+    /// Whatever the Wasm executable wrote to stderr.
     pub stderr: Vec<u8>,
 }
 
-/// WASM executable metadata, for human reasons.
+/// Wasm executable metadata, for human reasons.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Manifest {
-    /// Short name of this WASM manifest. Lower-cased alphanumerics plus underscore.
+    /// Short name of this Wasm manifest. Lower-cased alphanumerics plus underscore.
     name: String,
-    /// The namespace this WASM manifest belongs to.
+    /// The namespace this Wasm manifest belongs to.
     namespace: String,
     /// A semver-compatible version string. Semver not yet enforced.
     version: String,
-    /// Path to a compiled WASM exectuable.
+    /// Path to a compiled Wasm exectuable.
     binary: PathBuf,
     /// Human-readable description.
     description: String,


### PR DESCRIPTION
The agent and the cli now both attempt to join a network of peers, established via kaboodle, and use that network instead of mdns to discover relevant services. 

The most interesting implementation details are in the file `utils/src/mesh.rs`. This file includes some wrapper traits that probably belong in Kaboodle itself, since they were designed to be re-usable and to encode the responsibilities of any Kaboodle implementation: KaboodleMesh and KaboodlePeer. There are implementations plus some serval-specific functions in the structs ServalMesh and PeerMetadata. (All names are negotiable. I already don't like my initial choices.)

The peer metadata struct gets a little complicated because I attempted to provide some future-proofing via a way to version it. It's encoded via `binencode`, with a version envelope wrapper to allow us to make newer agents that change what gets packed into identity able to interoperate with older agents, and let older agents ignore newer ones. I welcome improvements to this somewhat ad-hoc design.

Agent roles are now an enum, `ServalRoles`. The `strum` crate provides Display and FromString implementations. This adds some safety and validity-checking to what had been some magic strings.

We knew we'd stop blocking in the cli some day, and this is that day: the cli is now fully async.

Finally, and most noisily, corrected the spelling of "Wasm" everywhere. Apologies for that.