### PR TITLE
Mesh shenanigans in the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b49bd4c5b769125ea6323601c39815848972880efd33ffb2d01f9f909adc699"
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,8 +2508,10 @@ name = "serval"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-once-cell",
  "atty",
  "clap 3.2.23",
+ "dotenvy",
  "humansize",
  "log",
  "loggerv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "kaboodle"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b56c34dcd41521d20730068fcab939a8a304a9881836488bb66f4a7c1a77d4"
+checksum = "a9f79b530578ef7c5a9698aff9ea60883aeb4204b37e37dac3198a94258aa302"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,28 +2676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,7 +3157,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "ssri",
- "strum",
  "thiserror",
  "tokio 1.27.0",
  "tokio-util",

--- a/agent/src/api/v1/mesh.rs
+++ b/agent/src/api/v1/mesh.rs
@@ -1,0 +1,30 @@
+use axum::{
+    extract::{Path, State},
+    response::IntoResponse,
+    routing::get,
+    Json,
+};
+use utils::mesh::{KaboodleMesh, PeerMetadata, ServalRole};
+
+use crate::structures::*;
+
+/// Mount all mesh-related introspection endpoints.
+pub fn mount(router: ServalRouter) -> ServalRouter {
+    router
+        .route("/v1/mesh/peers/:role", get(filter_peers)) // TODO
+        .route("/v1/mesh/peers", get(list_peers)) // TODO
+}
+
+/// List all known peers.
+async fn list_peers(_state: State<AppState>) -> Json<Vec<PeerMetadata>> {
+    let mesh = MESH.get().expect("Peer network not initialized!"); // yes, we crash in this case
+    let peers = mesh.peers().await;
+    Json(peers)
+}
+
+/// Filter known peers to only those that advertise the specific role.
+async fn filter_peers(Path(role): Path<ServalRole>, _state: State<AppState>) -> impl IntoResponse {
+    let mesh = MESH.get().expect("Peer network not initialized!"); // yes, we crash in this case
+    let peers = mesh.peers_with_role(&role).await;
+    Json(peers)
+}

--- a/agent/src/api/v1/mod.rs
+++ b/agent/src/api/v1/mod.rs
@@ -1,3 +1,4 @@
 pub mod jobs;
+pub mod mesh;
 pub mod proxy;
 pub mod storage;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -115,6 +115,7 @@ async fn main() -> Result<()> {
     let mut router: Router<Arc<RunnerState>, Body> = Router::new()
         .route("/monitor/ping", get(ping))
         .route("/monitor/status", get(monitor_status));
+    router = v1::mesh::mount(router);
 
     // NOTE: We have two of these now. If we develop a third, generalize this pattern.
     router = if state.has_storage {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -17,7 +17,7 @@ use axum::{
 };
 use dotenvy::dotenv;
 use engine::ServalEngine;
-use utils::mesh::{KaboodleMesh, PeerMetadata, ServalMesh, ServalRole};
+use utils::mesh::{mesh_interface_and_port, KaboodleMesh, PeerMetadata, ServalMesh, ServalRole};
 use utils::networking::find_nearest_port;
 use uuid::Uuid;
 
@@ -185,16 +185,12 @@ async fn main() -> Result<()> {
         log::info!("job running not enabled (or not supported)");
     }
 
-    let mesh_port: u16 = match std::env::var("MESH_PORT") {
-        Ok(port_str) => port_str.parse::<u16>().unwrap_or(8181),
-        Err(_) => 8181,
-    };
-
     let host_ip = host.parse()?;
     let http_addr = SocketAddr::new(host_ip, port);
+    let (mesh_port, mesh_interface) = mesh_interface_and_port();
 
     let metadata = PeerMetadata::new(Uuid::new_v4().to_string(), Some(http_addr), roles, None);
-    let mut mesh = ServalMesh::new(metadata, mesh_port, None).await?;
+    let mut mesh = ServalMesh::new(metadata, mesh_interface, mesh_port).await?;
     mesh.start().await?;
     MESH.set(mesh).unwrap();
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,8 +6,10 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow = { workspace = true }
+async-once-cell = "0.4.4"
 atty = { workspace = true  }
 clap = { version = "3.2.23", features = ["derive", "wrap_help"] } # older version on purpose
+dotenvy = { workspace = true  }
 humansize = "2.1.3"
 log = { workspace = true }
 loggerv = "0.7.2"

--- a/cli/src/mesh.rs
+++ b/cli/src/mesh.rs
@@ -1,0 +1,49 @@
+use owo_colors::OwoColorize;
+use tokio::time::sleep;
+
+use std::time::Duration;
+
+use utils::mesh::{KaboodlePeer, PeerMetadata};
+
+pub async fn monitor_mesh() -> anyhow::Result<()> {
+    println!("Monitoring mesh ...");
+    let mut mesh = super::peers::create_mesh_peer().await?;
+    let mut discover_rx = mesh
+        .discover_peers()
+        .expect("Unable to get arrivals channel!");
+    let mut depart_rx = mesh
+        .discover_departures()
+        .expect("Unable to get departures channel!");
+
+    loop {
+        if let Some((addr, identity)) = discover_rx.recv().await {
+            let peer = PeerMetadata::from_identity(addr, identity.to_vec());
+            if let Some(peer_address) = peer.address() {
+                print!(
+                    "✅ {} {} @ {peer_address}",
+                    "JOINED:".blue(),
+                    peer.instance_id()
+                );
+            } else {
+                print!(
+                    "⚠️ {} {} peer with no address",
+                    "JOINED:".blue(),
+                    peer.instance_id()
+                );
+            }
+            println!(
+                "; roles: {}",
+                peer.roles()
+                    .iter()
+                    .map(|xs| xs.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            );
+        }
+        if let Some(addr) = depart_rx.recv().await {
+            println!("❌ {} {}", "DEPARTED:".red(), addr);
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+    // on ctrl-C, clean up?
+}

--- a/cli/src/mesh.rs
+++ b/cli/src/mesh.rs
@@ -43,7 +43,7 @@ pub async fn monitor_mesh() -> anyhow::Result<()> {
         if let Some(addr) = depart_rx.recv().await {
             println!("❌ {} {}", "DEPARTED:".red(), addr);
         }
-        sleep(Duration::from_secs(5)).await;
+        sleep(Duration::from_secs(1)).await;
     }
     // on ctrl-C, clean up?
 }

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -38,9 +38,9 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
     let (port, interface) = utils::mesh::mesh_interface_and_port();
 
     let metadata = PeerMetadata::new(
-        format!("client@{host}"),
+        format!("observer@{host}"),
         None,
-        vec![ServalRole::Client],
+        vec![ServalRole::Observer],
         None,
     );
     let mut mesh = ServalMesh::new(metadata, interface, port).await?;

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -1,0 +1,81 @@
+// Finding a peer at most once, so we can build urls.
+
+use anyhow::{anyhow, Result};
+use async_once_cell::OnceCell;
+use tokio::time::sleep;
+use utils::mesh::{KaboodleMesh, PeerMetadata, ServalMesh, ServalRole};
+
+use std::{net::SocketAddr, time::Duration};
+
+static SERVAL_NODE_ADDR: OnceCell<SocketAddr> = async_once_cell::OnceCell::new();
+
+async fn base_url() -> SocketAddr {
+    *SERVAL_NODE_ADDR
+        .get_or_init(async {
+            maybe_find_peer(None, "SERVAL_NODE_URL")
+                .await
+                .expect("unable to find any mesh peers!")
+        })
+        .await
+}
+
+// Convenience function to build urls repeatably.
+pub async fn build_url(path: String, version: Option<&str>) -> String {
+    let baseurl = base_url().await;
+    if let Some(v) = version {
+        format!("http://{baseurl}/v{v}/{path}")
+    } else {
+        format!("http://{baseurl}/{path}")
+    }
+}
+
+pub async fn create_mesh_peer() -> Result<ServalMesh> {
+    let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let (port, interface) = utils::mesh::mesh_interface_and_port();
+
+    let metadata = PeerMetadata::new(
+        format!("client@{host}"),
+        None,
+        vec![ServalRole::Client],
+        None,
+    );
+    let mut mesh = ServalMesh::new(metadata, interface, port).await?;
+    mesh.start().await?;
+    Ok(mesh)
+}
+
+async fn maybe_find_peer(role: Option<&ServalRole>, override_var: &str) -> Result<SocketAddr> {
+    if let Ok(override_url) = std::env::var(override_var) {
+        if let Ok(override_addr) = override_url.parse::<SocketAddr>() {
+            return Ok(override_addr);
+        }
+    }
+
+    log::info!("Looking for {role:?} node on the peer network...");
+    let mut mesh = create_mesh_peer().await?;
+
+    // There has to be a better way.
+    sleep(Duration::from_secs(20)).await;
+
+    let result = if let Some(role) = role {
+        let candidates = mesh.peers_with_role(role).await;
+        if let Some(target) = candidates.first() {
+            // we know that peers_with_role filters out candidates without http addresses
+            Ok(target.http_address().unwrap())
+        } else {
+            Err(anyhow!("Unable to locate a peer with the {role} role"))
+        }
+    } else {
+        // any peer will do
+        if let Some(target) = mesh.peers().await.first() {
+            // we know that peers_with_role filters out candidates without http addresses
+            Ok(target.http_address().unwrap())
+        } else {
+            Err(anyhow!("Unable to locate any peers on this mesh"))
+        }
+    };
+
+    mesh.stop().await?;
+
+    result
+}

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -11,7 +11,7 @@ static SERVAL_NODE_ADDR: OnceCell<SocketAddr> = async_once_cell::OnceCell::new()
 async fn base_url() -> SocketAddr {
     *SERVAL_NODE_ADDR
         .get_or_init(async {
-            maybe_find_peer(None, "SERVAL_NODE_URL")
+            maybe_find_peer("SERVAL_NODE_URL")
                 .await
                 .expect("unable to find any mesh peers!")
         })
@@ -48,18 +48,18 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
     Ok(mesh)
 }
 
-async fn maybe_find_peer(role: Option<&ServalRole>, override_var: &str) -> Result<SocketAddr> {
+async fn maybe_find_peer(override_var: &str) -> Result<SocketAddr> {
     if let Ok(override_url) = std::env::var(override_var) {
         if let Ok(override_addr) = override_url.parse::<SocketAddr>() {
             return Ok(override_addr);
         }
     }
 
-    log::info!("Looking for {role:?} node on the peer network...");
+    log::info!("Looking for any node on the peer network...");
     let peer = discover_peer().await?;
     if let Some(addr) = peer.http_address() {
         Ok(addr)
     } else {
-        Err(anyhow!("Unable to locate a peer with the {role:?} role"))
+        Err(anyhow!("Unable to locate a peer"))
     }
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -22,7 +22,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
 ssri = "8.0.0"
-strum = { version="0.24.1", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,7 +14,7 @@ bincode = "2.0.0-rc.2"
 cacache = { version = "11.0.0", default-features = false, features = ["tokio-runtime"] }
 hex = "0.4.3"
 if-addrs = "0.10.1"
-kaboodle = "0.1.3"
+kaboodle = "0.1.4"
 log = { workspace = true }
 mdns-sd = { workspace = true }
 reqwest = { workspace = true }

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -212,10 +212,10 @@ pub async fn discover() -> Result<PeerMetadata, KaboodleError> {
 }
 
 pub fn mesh_interface_and_port() -> (Option<if_addrs::Interface>, u16) {
-    let mesh_port: u16 = match std::env::var("MESH_PORT") {
-        Ok(port_str) => port_str.parse::<u16>().unwrap_or(8181),
-        Err(_) => 8181,
-    };
+    let mesh_port: u16 = std::env::var("MESH_PORT")
+        .ok()
+        .map(|port_str| port_str.parse().expect("Invalid value given for MESH_PORT"))
+        .unwrap_or(8181);
     let mesh_interface = match std::env::var("MESH_INTERFACE") {
         Ok(v) => crate::networking::get_interface(&v),
         Err(_) => None,

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -3,7 +3,6 @@ use bincode::{Decode, Encode};
 use if_addrs::Interface;
 use kaboodle::{errors::KaboodleError, Kaboodle};
 use serde::{Deserialize, Serialize};
-use strum::{Display, EnumString};
 
 use std::net::SocketAddr;
 
@@ -34,15 +33,22 @@ pub trait KaboodlePeer {
 // End of tiny wrapper around Kaboodle.
 
 /// These are the roles we allow peers to advertise on the mesh
-#[derive(
-    Debug, Clone, PartialEq, Eq, Display, EnumString, Decode, Encode, Deserialize, Serialize,
-)]
-#[strum(serialize_all = "lowercase")]
+#[derive(Debug, Clone, PartialEq, Eq, Decode, Encode, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ServalRole {
     Runner,
     Storage,
     Client,
+}
+
+impl std::fmt::Display for ServalRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServalRole::Runner => write!(f, "runner"),
+            ServalRole::Storage => write!(f, "storage"),
+            ServalRole::Client => write!(f, "client"),
+        }
+    }
 }
 
 // An envelope that holds a version number. A little bit of future-proofing

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -38,7 +38,7 @@ pub trait KaboodlePeer {
 pub enum ServalRole {
     Runner,
     Storage,
-    Client,
+    Observer,
 }
 
 impl std::fmt::Display for ServalRole {
@@ -46,7 +46,7 @@ impl std::fmt::Display for ServalRole {
         match self {
             ServalRole::Runner => write!(f, "runner"),
             ServalRole::Storage => write!(f, "storage"),
-            ServalRole::Client => write!(f, "client"),
+            ServalRole::Observer => write!(f, "observer"),
         }
     }
 }

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -1,9 +1,39 @@
+use if_addrs::Interface;
 use if_addrs::{IfAddr, Ifv4Addr};
 
 use std::net::Ipv4Addr;
 use std::net::TcpListener;
 
 use crate::errors::ServalError;
+
+pub fn get_interface(specified_interface: &str) -> Option<Interface> {
+    match specified_interface {
+        "ipv4" => non_loopback_interfaces()
+            .into_iter()
+            .find(|iface| matches!(iface.addr, IfAddr::V4(_))),
+        "ipv6" => non_loopback_interfaces()
+            .into_iter()
+            .find(|iface| matches!(iface.addr, IfAddr::V6(_))),
+        ip_or_name => {
+            // Use the first interface we find where the interface name (e.g. `en0` or IP
+            // address matches the argument. Note that we don't do any canonicalization on the
+            // input value; for IPv6, addresses should be provided in their full, uncompressed
+            // format.
+            non_loopback_interfaces()
+                .into_iter()
+                .find(|iface| iface.addr.ip().to_string() == ip_or_name || iface.name == ip_or_name)
+        }
+    }
+}
+
+/// Get all non-loopback interfaces for this host.
+fn non_loopback_interfaces() -> Vec<Interface> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|addr| !addr.is_loopback())
+        .collect()
+}
 
 /// Get all non-loopback ipv4 addresses for this host.
 pub fn my_ipv4_addrs() -> Vec<Ipv4Addr> {


### PR DESCRIPTION
Three changes, two notable!

1. Added a new `monitor` command to the cli. This command joins the cli to the mesh as a `client` role, and prints out joins and leaves as it is informed of them.

The CLI and the agent both now respect a new env var: `MESH_INTERFACE`. If you don't provide one, kaboodle defaults to the best it can find. If you do provide a string here, we find an interface with a matching name. This allows me to specify ipv4 and therefore run tests successfully locally.

The CLI now only connects to a mesh to get a base url if it ever needs a base url. It doesn't need a base url for this command, for instance. This change caused a lot of trauma in the cli as things became async that were not previously so. tl;dr the CLI now uses `async_once_cell`.

Generalized some other things as needed. Stole some network interface selection code from kaboodle itself. (We might want to have kaboodle take an interface suggestion via string; worth thinking about anyway.)

2. The CLI now uses the single-peer discovery affordance in the latest Kaboodle. This speeds up all CLI operations _considerably_.

Added new endpoints to the agent to support requesting and receiving lists of peers via the HTTP api. Wrapped kaboodle's new discover-a-peer api in a new `mesh::discover()` function that reuses our env var hinting code. Reworked the CLI's http base url discovery code to use the the new `discover()` function. This code simplified a lot!

`PeerMetadata` and `ServalRole` now both are serializable via Serde.

3. Nuked strum. Strum is nice and it does handy things, but we were only using it for a fairly trivial-to-implement display trait for ServalRole.