### PR TITLE
ServalMesh grab bag

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -192,7 +192,7 @@ fn init_config() -> Config {
 
 fn init_metrics() {
     // TODO: This should switch on which set of metrics features we're building with.
-    let metrics_addr = std::env::var("METRICS_ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
+    let metrics_addr = std::env::var("METRICS_ADDR").unwrap_or_else(|_| "[::]:9000".to_string());
     let addr: SocketAddr = metrics_addr.parse().unwrap();
     let builder = TcpBuilder::new().listen_address(addr);
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -140,15 +140,15 @@ async fn main() -> Result<()> {
         Err(_) => None,
     };
 
-    let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let host = std::env::var("HOST").unwrap_or_else(|_| "[::]".to_string());
 
     // Start the Axum server; this is in a loop so we can try binding more than once in case our
     // randomly-selected port number ends up conflicting with something else due to a race condition.
-    let mut port: u16;
+    let mut http_addr: SocketAddr;
     let server: Server<_, _> = loop {
-        port = predefined_port.unwrap_or_else(|| find_nearest_port(8100).unwrap());
-        let addr: SocketAddr = format!("{host}:{port}").parse().unwrap();
-        match axum::Server::try_bind(&addr) {
+        let port = predefined_port.unwrap_or_else(|| find_nearest_port(8100).unwrap());
+        http_addr = format!("{host}:{port}").parse().unwrap();
+        match axum::Server::try_bind(&http_addr) {
             Ok(builder) => break builder.serve(app.into_make_service()),
             Err(_) => {
                 // Port number in use already, presumably
@@ -160,7 +160,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    log::info!("serval agent http will listen on {host}:{port}");
+    log::info!("serval agent http will listen on {http_addr}");
 
     if let Some(extensions_path) = extensions_path {
         let extensions = &state.extensions;
@@ -186,10 +186,7 @@ async fn main() -> Result<()> {
         log::info!("job running not enabled (or not supported)");
     }
 
-    let host_ip = host.parse()?;
-    let http_addr = SocketAddr::new(host_ip, port);
     let (mesh_port, mesh_interface) = mesh_interface_and_port();
-
     let metadata = PeerMetadata::new(Uuid::new_v4().to_string(), Some(http_addr), roles, None);
     let mut mesh = ServalMesh::new(metadata, mesh_interface, mesh_port).await?;
     mesh.start().await?;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -41,15 +41,7 @@ async fn main() -> Result<()> {
     }
     env_logger::init();
 
-    // TODO: This should switch on which set of metrics features we're building with.
-    let metrics_addr = std::env::var("METRICS_ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
-    let addr: SocketAddr = metrics_addr.parse().unwrap();
-    let builder = TcpBuilder::new().listen_address(addr);
-
-    if let Err(err) = builder.install() {
-        log::warn!("failed to install TCP recorder: {err:?}");
-    };
-    metrics::increment_counter!("process:start", "component" => "agent");
+    init_metrics();
 
     let storage_role = match &std::env::var("STORAGE_ROLE").unwrap_or_else(|_| "auto".to_string())[..]
     {
@@ -195,4 +187,16 @@ async fn main() -> Result<()> {
     // And finally, listen on HTTP.
     server.await.unwrap();
     Ok(())
+}
+
+fn init_metrics() {
+    // TODO: This should switch on which set of metrics features we're building with.
+    let metrics_addr = std::env::var("METRICS_ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
+    let addr: SocketAddr = metrics_addr.parse().unwrap();
+    let builder = TcpBuilder::new().listen_address(addr);
+
+    if let Err(err) = builder.install() {
+        log::warn!("failed to install TCP recorder: {err:?}");
+    };
+    metrics::increment_counter!("process:start", "component" => "agent");
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -153,7 +153,12 @@ async fn main() -> Result<()> {
     }
 
     let (mesh_interface, mesh_port) = mesh_interface_and_port();
-    let metadata = PeerMetadata::new(Uuid::new_v4().to_string(), Some(http_addr), roles, None);
+    let metadata = PeerMetadata::new(
+        Uuid::new_v4().to_string(),
+        Some(http_addr.port()),
+        roles,
+        None,
+    );
     let mut mesh = ServalMesh::new(metadata, mesh_port, Some(mesh_interface)).await?;
     mesh.start().await?;
     MESH.set(mesh).unwrap();

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -157,7 +157,7 @@ async fn main() -> Result<()> {
         Uuid::new_v4().to_string(),
         Some(http_addr.port()),
         roles,
-        None,
+        mesh_interface.ip(),
     );
     let mut mesh = ServalMesh::new(metadata, mesh_port, Some(mesh_interface)).await?;
     mesh.start().await?;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> Result<()> {
     let extensions_path = std::env::var("EXTENSIONS_PATH").ok().map(PathBuf::from);
 
     let instance_id = Uuid::new_v4();
+    log::info!("instance id {instance_id}");
     let state = Arc::new(RunnerState::new(
         instance_id,
         blob_path.clone(),

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -175,7 +175,12 @@ fn init_config() -> Config {
 
     let extensions_path = std::env::var("EXTENSIONS_PATH").ok().map(PathBuf::from);
 
-    let instance_id = Uuid::new_v4();
+    let instance_id: Uuid = std::env::var("INSTANCE_ID")
+        .ok()
+        .map(|uuid_str| {
+            Uuid::parse_str(&uuid_str).expect("Invalid INSTANCE_ID value; must be a UUID")
+        })
+        .unwrap_or_else(Uuid::new_v4);
 
     Config {
         instance_id,

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -152,9 +152,9 @@ async fn main() -> Result<()> {
         log::info!("job running not enabled (or not supported)");
     }
 
-    let (mesh_port, mesh_interface) = mesh_interface_and_port();
+    let (mesh_interface, mesh_port) = mesh_interface_and_port();
     let metadata = PeerMetadata::new(Uuid::new_v4().to_string(), Some(http_addr), roles, None);
-    let mut mesh = ServalMesh::new(metadata, mesh_interface, mesh_port).await?;
+    let mut mesh = ServalMesh::new(metadata, mesh_port, Some(mesh_interface)).await?;
     mesh.start().await?;
     MESH.set(mesh).unwrap();
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -127,17 +127,16 @@ async fn main() -> Result<()> {
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE_BYTES))
         .with_state(state.clone());
 
-    let predefined_port: Option<u16> = match std::env::var("PORT") {
-        Ok(port_str) => port_str.parse::<u16>().ok(),
-        Err(_) => None,
-    };
-
     let host = std::env::var("HOST").unwrap_or_else(|_| "[::]".to_string());
 
     // Start the Axum server; this is in a loop so we can try binding more than once in case our
     // randomly-selected port number ends up conflicting with something else due to a race condition.
     let mut http_addr: SocketAddr;
     let server: Server<_, _> = loop {
+        let predefined_port: Option<u16> = match std::env::var("PORT") {
+            Ok(port_str) => port_str.parse::<u16>().ok(),
+            Err(_) => None,
+        };
         let port = predefined_port.unwrap_or_else(|| find_nearest_port(8100).unwrap());
         http_addr = format!("{host}:{port}").parse().unwrap();
         match axum::Server::try_bind(&http_addr) {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -104,16 +104,14 @@ async fn main() -> Result<()> {
 
     let app = init_router(&state);
 
-    let host = std::env::var("HOST").unwrap_or_else(|_| "[::]".to_string());
-
     // Start the Axum server; this is in a loop so we can try binding more than once in case our
     // randomly-selected port number ends up conflicting with something else due to a race condition.
     let mut http_addr: SocketAddr;
     let server: Server<_, _> = loop {
-        let predefined_port: Option<u16> = match std::env::var("PORT") {
-            Ok(port_str) => port_str.parse::<u16>().ok(),
-            Err(_) => None,
-        };
+        let host = std::env::var("HOST").unwrap_or_else(|_| "[::]".to_string());
+        let predefined_port = std::env::var("PORT")
+            .ok()
+            .and_then(|port_str| port_str.parse::<u16>().ok());
         let port = predefined_port.unwrap_or_else(|| find_nearest_port(8100).unwrap());
         http_addr = format!("{host}:{port}").parse().unwrap();
         match axum::Server::try_bind(&http_addr) {

--- a/cli/src/mesh.rs
+++ b/cli/src/mesh.rs
@@ -16,13 +16,13 @@ pub async fn monitor_mesh() -> anyhow::Result<()> {
         .expect("Unable to get departures channel!");
 
     loop {
-        if let Some((addr, identity)) = discover_rx.recv().await {
+        while let Some((addr, identity)) = discover_rx.recv().await {
             let peer = PeerMetadata::from_identity(addr, identity.to_vec());
             if let Some(peer_address) = peer.address() {
                 print!(
                     "✅ {} {} @ {peer_address}",
                     "JOINED:".blue(),
-                    peer.instance_id()
+                    peer.instance_id(),
                 );
             } else {
                 print!(
@@ -31,16 +31,22 @@ pub async fn monitor_mesh() -> anyhow::Result<()> {
                     peer.instance_id()
                 );
             }
-            println!(
-                "; roles: {}",
-                peer.roles()
-                    .iter()
-                    .map(|xs| xs.to_string())
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            );
+            if !peer.roles().is_empty() {
+                print!(
+                    "; roles: {}",
+                    peer.roles()
+                        .iter()
+                        .map(|xs| xs.to_string())
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                );
+            }
+            if let Some(http_addr) = peer.http_address() {
+                print!("; http port: {}", http_addr.port());
+            }
+            println!();
         }
-        if let Some(addr) = depart_rx.recv().await {
+        while let Some(addr) = depart_rx.recv().await {
             println!("❌ {} {}", "DEPARTED:".red(), addr);
         }
         sleep(Duration::from_secs(1)).await;

--- a/cli/src/mesh.rs
+++ b/cli/src/mesh.rs
@@ -17,20 +17,8 @@ pub async fn monitor_mesh() -> anyhow::Result<()> {
 
     loop {
         while let Some((addr, identity)) = discover_rx.recv().await {
-            let peer = PeerMetadata::from_identity(addr, identity.to_vec());
-            if let Some(peer_address) = peer.address() {
-                print!(
-                    "✅ {} {} @ {peer_address}",
-                    "JOINED:".blue(),
-                    peer.instance_id(),
-                );
-            } else {
-                print!(
-                    "⚠️ {} {} peer with no address",
-                    "JOINED:".blue(),
-                    peer.instance_id()
-                );
-            }
+            let peer = PeerMetadata::from_identity(addr.ip(), identity.to_vec());
+            print!("✅ {} {} @ {addr}", "JOINED:".blue(), peer.instance_id(),);
             if !peer.roles().is_empty() {
                 print!(
                     "; roles: {}",

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -37,11 +37,13 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
     let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let (interface, port) = utils::mesh::mesh_interface_and_port();
 
+    let http_port = None;
+    let address = None;
     let metadata = PeerMetadata::new(
         format!("observer@{host}"), // todo: should this just be a UUID like it is for everyone else?
-        None,
+        http_port,
         vec![ServalRole::Observer],
-        None,
+        address,
     );
     let mut mesh = ServalMesh::new(metadata, port, Some(interface)).await?;
     mesh.start().await?;

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -38,7 +38,7 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
     let (interface, port) = utils::mesh::mesh_interface_and_port();
 
     let metadata = PeerMetadata::new(
-        format!("observer@{host}"),
+        format!("observer@{host}"), // todo: should this just be a UUID like it is for everyone else?
         None,
         vec![ServalRole::Observer],
         None,

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -35,7 +35,7 @@ async fn discover_peer() -> Result<PeerMetadata> {
 
 pub async fn create_mesh_peer() -> Result<ServalMesh> {
     let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-    let (port, interface) = utils::mesh::mesh_interface_and_port();
+    let (interface, port) = utils::mesh::mesh_interface_and_port();
 
     let metadata = PeerMetadata::new(
         format!("observer@{host}"),
@@ -43,7 +43,7 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
         vec![ServalRole::Observer],
         None,
     );
-    let mut mesh = ServalMesh::new(metadata, interface, port).await?;
+    let mut mesh = ServalMesh::new(metadata, port, Some(interface)).await?;
     mesh.start().await?;
     Ok(mesh)
 }

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -49,10 +49,11 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
 }
 
 async fn maybe_find_peer(override_var: &str) -> Result<SocketAddr> {
-    if let Ok(override_url) = std::env::var(override_var) {
-        if let Ok(override_addr) = override_url.parse::<SocketAddr>() {
-            return Ok(override_addr);
-        }
+    if let Some(override_addr) = std::env::var(override_var)
+        .ok()
+        .and_then(|override_url| override_url.parse::<SocketAddr>().ok())
+    {
+        return Ok(override_addr);
     }
 
     log::info!("Looking for any node on the peer network...");

--- a/cli/src/peers.rs
+++ b/cli/src/peers.rs
@@ -38,12 +38,11 @@ pub async fn create_mesh_peer() -> Result<ServalMesh> {
     let (interface, port) = utils::mesh::mesh_interface_and_port();
 
     let http_port = None;
-    let address = None;
     let metadata = PeerMetadata::new(
         format!("observer@{host}"), // todo: should this just be a UUID like it is for everyone else?
         http_port,
         vec![ServalRole::Observer],
-        address,
+        interface.ip(),
     );
     let mut mesh = ServalMesh::new(metadata, port, Some(interface)).await?;
     mesh.start().await?;

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -71,7 +71,7 @@ pub struct PeerMetadata {
 #[derive(Debug, Clone, Decode, Encode, Deserialize, Serialize)]
 struct MetadataInner {
     instance_id: String,
-    http_address: Option<SocketAddr>, // this is an option because CLIs don't have one
+    http_port: Option<u16>,
     roles: Vec<ServalRole>,
 }
 
@@ -79,13 +79,13 @@ impl PeerMetadata {
     /// Create a new metadata node from useful information.
     pub fn new(
         instance_id: String,
-        http_address: Option<SocketAddr>,
+        http_port: Option<u16>,
         roles: Vec<ServalRole>,
         address: Option<SocketAddr>,
     ) -> Self {
         let inner = MetadataInner {
             instance_id,
-            http_address,
+            http_port,
             roles,
         };
         Self { address, inner }
@@ -103,7 +103,14 @@ impl PeerMetadata {
 
     /// Get the advertised http address of this peer.
     pub fn http_address(&self) -> Option<SocketAddr> {
-        self.inner.http_address
+        let Some(http_port) = self.inner.http_port else {
+            return None;
+        };
+        self.address.map(|addr| {
+            let mut addr = addr.clone();
+            addr.set_port(http_port);
+            addr
+        })
     }
 }
 

--- a/utils/src/mesh.rs
+++ b/utils/src/mesh.rs
@@ -221,6 +221,10 @@ pub fn mesh_interface_and_port() -> (if_addrs::Interface, u16) {
             .expect("Failed to find interface matching MESH_INTERFACE value"),
         Err(_) => crate::networking::best_available_interface().expect("No available interfaces"),
     };
-    log::info!("connecting to the mesh on port {mesh_port} over {mesh_interface:?}");
+    log::info!(
+        "connecting to the mesh on port {mesh_port} over {} ({})",
+        mesh_interface.name,
+        mesh_interface.ip()
+    );
     (mesh_interface, mesh_port)
 }

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -26,6 +26,20 @@ pub fn get_interface(specified_interface: &str) -> Option<Interface> {
     }
 }
 
+/// Returns the best available network interface. Only non-loopback interfaces are considered, and
+/// IPv6 interfaces are preferred.
+pub fn best_available_interface() -> Option<Interface> {
+    // If no interface was provided, use the first IPv6 interface we find, and if there are
+    // no IPv6 interfaces, use the first IPv4 interface.
+    let non_loopbacks = non_loopback_interfaces();
+    let first_ipv6_interface = non_loopbacks
+        .iter()
+        .find(|xs| matches!(xs.addr, IfAddr::V6(_)));
+    first_ipv6_interface
+        .or_else(|| non_loopbacks.first())
+        .cloned()
+}
+
 /// Get all non-loopback interfaces for this host.
 fn non_loopback_interfaces() -> Vec<Interface> {
     if_addrs::get_if_addrs()


### PR DESCRIPTION
Lots of tiny commits here; sorry. Most of them are just cleaning up a handful of lines of code to be a bit more idiomatic.

The highlights:
- I pulled some chunks out of serval-agent's `main` function, creating a handful of `init_…()` functions just to give us a bit of containment
- I added an `INSTANCE_ID` environment variable to allow you to give a node a persistent identity
- KaboodlePeer - replace `Option<SocketAddr>` with `IpAddr` — this is explained extensively in the commit message
- Updated `HOST` and `METRICS_ADDR` to use IPv6 wildcards (`[::]`) by default rather than IPv4 (`0.0.0.0`). (`HOST` should probably be renamed; any suggestions for a better name?)