### PR TITLE
Build releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,9 @@
 name: Build Serval
 
-on: [push]
-# on:
-#   push:
-#     tags:
-#       - 'v*'
+on:
+  push:
+    tags:
+      - 'v*'
 
 env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install libssl-dev
+        run: sudo apt-get install -y libssl-dev
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,88 @@
+name: Build Serval
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+      CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: create a github release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: serval-mesh ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+  build:
+    name: build for linux
+    runs-on: ubuntu-latest
+    needs: [release]
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            target: x86_64-unknown-linux-gnu
+            cross: false
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
+            cross: true
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          use-cross: ${{ matrix.cross }}
+          args: --release --target ${{ matrix.target }}
+
+      # TODO: might want to add this to CLI at some point
+      # - name: write out completions
+      #   run: |
+      #     ./target/release/serval completions bash > completions.bash
+      #     ./target/release/serval completions zsh > completions.zsh
+      #     ./target/release/serval completions fish > completions.fish
+
+      - name: tar it up
+        run: |
+          tar cf serval-mesh_${{ matrix.arch }}_linux.tar -C target/release serval serval-mesh test-runner
+          # tar f serval-mesh_${{ matrix.arch }}_linux.tar -r completions.bash completions.zsh completions.fish
+          gzip serval-mesh_${{ matrix.arch }}_linux.tar
+
+      - name: upload ${{ matrix.arch }} linux release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{needs.release.outputs.upload_url}}
+          asset_path: serval-mesh_${{ matrix.arch }}_linux.tar.gz
+          asset_name: serval-mesh_${{ matrix.arch }}_linux.tar.gz
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,6 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-        fail-fast: true
-        max-parallel: 1
         include:
           - arch: amd64
             target: x86_64-unknown-linux-gnu
@@ -43,6 +41,8 @@ jobs:
           - arch: arm64
             target: aarch64-unknown-linux-gnu
             cross: true
+      fail-fast: true
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
 
@@ -101,8 +101,6 @@ jobs:
     strategy:
       matrix:
         arch: [intel, arm]
-        fail-fast: true
-        max-parallel: 1
         include:
           - arch: intel
             target: x86_64-apple-darwin
@@ -110,6 +108,8 @@ jobs:
           - arch: arm
             target: aarch64-apple-darwin
             cross: true
+      fail-fast: true
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,10 @@
 name: Build Serval
-on:
-  push:
-    tags:
-      - 'v*'
+
+on: [push]
+# on:
+#   push:
+#     tags:
+#       - 'v*'
 
 env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: tar it up
         run: |
-          tar cf serval-mesh_${{ matrix.arch }}_linux.tar -C target/release serval serval-agent test-runner
+          tar cf serval-mesh_${{ matrix.arch }}_linux.tar -C target/${{ matrix.target }}/release serval serval-agent test-runner
           # tar f serval-mesh_${{ matrix.arch }}_linux.tar -r completions.bash completions.zsh completions.fish
           gzip serval-mesh_${{ matrix.arch }}_linux.tar
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: tar up the Mac ${{ matrix.arch }} release
         run: |
-          tar cf serval-mesh_${{ matrix.arch }}_darwin.tar -C target/release serval serval-agent test-runner
+          tar cf serval-mesh_${{ matrix.arch }}_darwin.tar -C target/${{ matrix.target }}/release serval serval-agent test-runner
           # tar f serval-mesh_${{ matrix.arch }}_darwin.tar -r completions.bash completions.zsh completions.fish
           gzip serval-mesh_${{ matrix.arch }}_darwin.tar
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
           draft: true
           prerelease: false
 
-  build:
+  linux:
     name: build for linux
     runs-on: ubuntu-latest
     needs: [release]
@@ -73,7 +73,7 @@ jobs:
 
       - name: tar it up
         run: |
-          tar cf serval-mesh_${{ matrix.arch }}_linux.tar -C target/release serval serval-mesh test-runner
+          tar cf serval-mesh_${{ matrix.arch }}_linux.tar -C target/release serval serval-agent test-runner
           # tar f serval-mesh_${{ matrix.arch }}_linux.tar -r completions.bash completions.zsh completions.fish
           gzip serval-mesh_${{ matrix.arch }}_linux.tar
 
@@ -85,4 +85,60 @@ jobs:
           upload_url: ${{needs.release.outputs.upload_url}}
           asset_path: serval-mesh_${{ matrix.arch }}_linux.tar.gz
           asset_name: serval-mesh_${{ matrix.arch }}_linux.tar.gz
+          asset_content_type: application/octet-stream
+
+  macos:
+    name: build for macos
+    runs-on: macos-latest
+    needs: [release]
+    strategy:
+      matrix:
+        arch: [intel, arm]
+        include:
+          - arch: intel
+            target: x86_64-apple-darwin
+            cross: false
+          - arch: arm
+            target: aarch64-apple-darwin
+            cross: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - run: rustup target install ${{ matrix.target }}
+        if: ${{ matrix.arch == 'arm'}}
+
+      - run: cargo build --target ${{ matrix.target }} --release
+
+      - name: write out completions
+        run: |
+          ./target/release/serval-mesh completions bash > completions.bash
+          ./target/release/serval-mesh completions zsh > completions.zsh
+          ./target/release/serval-mesh completions fish > completions.fish
+
+      - name: tar up the Mac ${{ matrix.arch }} release
+        run: |
+          tar cf serval-mesh_${{ matrix.arch }}_darwin.tar -C target/release serval serval-agent test-runner
+          # tar f serval-mesh_${{ matrix.arch }}_darwin.tar -r completions.bash completions.zsh completions.fish
+          gzip serval-mesh_${{ matrix.arch }}_darwin.tar
+
+      - name: upload darwin ${{ matrix.arch }} release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{needs.release.outputs.upload_url}}
+          asset_path: serval-mesh_${{ matrix.arch }}_darwin.tar.gz
+          asset_name: serval-mesh_${{ matrix.arch }}_darwin.tar.gz
           asset_content_type: application/octet-stream

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,8 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
+        fail-fast: true
+        max-parallel: 1
         include:
           - arch: amd64
             target: x86_64-unknown-linux-gnu
@@ -99,6 +101,8 @@ jobs:
     strategy:
       matrix:
         arch: [intel, arm]
+        fail-fast: true
+        max-parallel: 1
         include:
           - arch: intel
             target: x86_64-apple-darwin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,11 +121,12 @@ jobs:
 
       - run: cargo build --target ${{ matrix.target }} --release
 
-      - name: write out completions
-        run: |
-          ./target/release/serval-mesh completions bash > completions.bash
-          ./target/release/serval-mesh completions zsh > completions.zsh
-          ./target/release/serval-mesh completions fish > completions.fish
+      # TODO: might want to add this to CLI at some point
+      # - name: write out completions
+      #   run: |
+      #     ./target/release/serval-mesh completions bash > completions.bash
+      #     ./target/release/serval-mesh completions zsh > completions.zsh
+      #     ./target/release/serval-mesh completions fish > completions.fish
 
       - name: tar up the Mac ${{ matrix.arch }} release
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           toolchain: 1.68
           override: true
+          components: rustfmt, clippy
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.68
           override: true
 
       - uses: actions/cache@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,6 +1812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.3+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +1828,7 @@ checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "3.2.23", features = ["derive"] }
 dotenvy = "0.15.6"
 env_logger = "0.10.0"
 log = "0.4.17"
-reqwest = { version = "0.11.13",  default-features = false, features = ["brotli", "json", "rustls-tls", "stream"] }
+reqwest = { version = "0.11.13",  default-features = false, features = ["brotli", "json", "rustls-tls", "stream", "native-tls-vendored"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 ssri = "8.0.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.68"


### PR DESCRIPTION
Whipped up a [strongly-inspired-by-tomato](https://github.com/ceejbot/tomato/blob/v0.3.0/.github/workflows/build.yaml) build script. The main difference is using a matrix strategy to reduce the number of steps involved (no need to explicitly write out the build steps for amd64/arm64 separately).

The goal is to have a quick way to install Serval on machines without a Rust toolchain, which is beneficial for agents with low computing power (long build times) and for minimizing dependencies for running Serval in general.
