### PR TITLE
S3 buckets now support fetching content by address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml 0.7.3",
+ "urlencoding",
  "utils",
  "uuid",
 ]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -32,5 +32,6 @@ tokio = { workspace = true }
 tokio-stream = "0.1.12"
 tokio-util = { workspace = true }
 toml = { workspace = true }
+urlencoding = "2.1.2"
 utils = { path = "../utils" }
 uuid = { workspace = true }

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -65,7 +65,7 @@ async fn get_by_content_address(Path(address): Path<String>) -> impl IntoRespons
         return e.into_response()
     };
 
-    match storage.data_by_sri(integrity).await {
+    match storage.data_by_integrity(integrity).await {
         Ok(stream) => {
             let headers = [(
                 header::CONTENT_TYPE,
@@ -94,7 +94,7 @@ async fn has_content_address(Path(address): Path<String>) -> impl IntoResponse {
         return e.into_response()
     };
 
-    match storage.data_exists_by_sri(&integrity).await {
+    match storage.data_exists_by_integrity(&integrity).await {
         Ok(exists) => {
             if exists {
                 StatusCode::OK.into_response()

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -74,7 +74,7 @@ async fn get_by_content_address(Path(address): Path<String>) -> impl IntoRespons
 
             log::info!("Serving CAS data; address={}", &address);
             (headers, stream).into_response()
-        },
+        }
         Err(ServalError::DataNotFound(s)) => (StatusCode::NOT_FOUND, s).into_response(),
         Err(e) => {
             log::info!("Error serving CAS data; address={}; error={}", &address, e);
@@ -101,10 +101,14 @@ async fn has_content_address(Path(address): Path<String>) -> impl IntoResponse {
             } else {
                 StatusCode::NOT_FOUND.into_response()
             }
-        },
+        }
         Err(ServalError::DataNotFound(s)) => (StatusCode::NOT_FOUND, s).into_response(),
         Err(e) => {
-            log::info!("Error serving CAS data head; address={}; error={}", &address, e);
+            log::info!(
+                "Error serving CAS data head; address={}; error={}",
+                &address,
+                e
+            );
             e.into_response()
         }
     }
@@ -149,10 +153,7 @@ async fn get_manifest(
 
     match storage.manifest(&name).await {
         Ok(manifest) => {
-            let headers = [(
-                header::CONTENT_TYPE,
-                String::from("application/toml"),
-            )];
+            let headers = [(header::CONTENT_TYPE, String::from("application/toml"))];
             (headers, manifest.to_string()).into_response()
         }
         Err(ServalError::DataNotFound(s)) => (StatusCode::NOT_FOUND, s).into_response(),

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -71,7 +71,7 @@ async fn store_by_content_address(body: Bytes) -> impl IntoResponse {
                 bytes.len()
             );
             (StatusCode::CREATED, integrity.to_string()).into_response()
-        },
+        }
         Err(e) => e.into_response(),
     }
 }

--- a/agent/src/storage/blobs.rs
+++ b/agent/src/storage/blobs.rs
@@ -44,6 +44,11 @@ impl BlobStore {
         })
     }
 
+    pub async fn store_by_integrity(&self, bytes: &[u8]) -> ServalResult<Integrity> {
+        let integrity = cacache::write_hash(&self.location, bytes).await?;
+        Ok(integrity)
+    }
+
     /// Given a content address, return a read stream for the object stored there.
     /// Responds with an error if no object is found or if the address is invalid.
     pub async fn data_by_integrity(

--- a/agent/src/storage/bucket.rs
+++ b/agent/src/storage/bucket.rs
@@ -2,6 +2,7 @@ use aws_sdk_s3 as s3;
 use s3::error::ProvideErrorMetadata;
 use s3::primitives::ByteStream;
 use ssri::Integrity;
+use urlencoding::encode;
 use utils::errors::{ServalError, ServalResult};
 
 #[derive(Debug, Clone)]
@@ -20,39 +21,69 @@ impl S3Storage {
         })
     }
 
-    /// Check if the given data blob is present in our data store, by integrity hash.
-    pub async fn data_by_sri(&self, integrity: Integrity) -> ServalResult<ByteStream> {
-        let key = integrity.to_string();
+    /// Check if the given data blob is present in our data store, by integrity hash. Returns a stream.
+    pub async fn data_by_integrity(&self, integrity: &Integrity) -> ServalResult<ByteStream> {
         let object = self
             .client
             .get_object()
             .bucket(&self.bucket)
-            .key(key)
+            .key(encode(&integrity.to_string()))
             .send()
             .await?;
 
         Ok(object.body)
     }
 
+    pub async fn store_by_integrity(
+        &self,
+        integrity: &Integrity,
+        bytes: &[u8],
+    ) -> ServalResult<Integrity> {
+        let body = ByteStream::from(bytes.to_vec());
+        let result = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(encode(&integrity.to_string())) // integrity string is not url-safe!
+            .body(body)
+            .content_type("application/octet-stream")
+            .send()
+            .await;
+
+        match result {
+            Ok(_resp) => Ok(integrity.clone()),
+            Err(e) => {
+                log::info!("Error storing data in s3: {e:?}");
+
+                Err(ServalError::StorageError(format!(
+                    "unable to store data! integrity={integrity}; error={}",
+                    e.message().unwrap_or("cannot get error message from AWS")
+                )))
+            }
+        }
+    }
+
     /// Check if the given data blob is present in our data store, using its human key.
     pub async fn data_exists_by_key(&self, key: &str) -> ServalResult<bool> {
+        let integrity = self.lookup_integrity(key).await?;
         let result = self
             .client
             .head_object()
             .bucket(&self.bucket)
-            .key(key)
+            .key(&integrity)
             .send()
             .await;
         Ok(result.is_ok())
     }
 
-    /// Fetch data from the store by key.
+    /// Fetch data from the store by key. Returns a vec of u8.
     pub async fn data_by_key(&self, key: &str) -> ServalResult<Vec<u8>> {
+        let integrity = self.lookup_integrity(key).await?;
         let object = self
             .client
             .get_object()
             .bucket(&self.bucket)
-            .key(key)
+            .key(&integrity)
             .send()
             .await?;
         let chunks = object.body.collect().await?;
@@ -61,42 +92,74 @@ impl S3Storage {
 
     /// Fetch data by key as a readable byte stream.
     pub async fn stream_by_key(&self, key: &str) -> ServalResult<ByteStream> {
+        let integrity = self.lookup_integrity(key).await?;
         let object = self
             .client
             .get_object()
             .bucket(&self.bucket)
-            .key(key)
+            .key(&integrity)
             .send()
             .await?;
 
         Ok(object.body)
     }
 
+    /// Look up an integrity checksum for a given key. Url-encodes the integrity string.
+    /// Really cheap index. Feel free to replace.
+    async fn lookup_integrity(&self, key: &str) -> ServalResult<String> {
+        let keyfile = format!("{key}.integrity");
+        match self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&keyfile)
+            .send()
+            .await {
+                Ok(object) => {
+                    let chunks = object.body.collect().await?;
+                    let bytes = chunks.into_bytes().to_vec();
+                    let integrity_string = String::from_utf8(bytes)?;
+                    let encoded = encode(&integrity_string);
+                    Ok(encoded.to_string())
+                },
+                Err(e) => {
+                    log::info!("integrity checksum not found for key={key}; keyfile={keyfile}; error={e}");
+                    Err(ServalError::S3GetError(e))
+                },
+            }
+    }
+
     /// Store data by key.
     pub async fn store_by_key(&self, key: &str, bytes: &[u8]) -> ServalResult<Integrity> {
-        let sri = Integrity::from(bytes);
-        let body = ByteStream::from(bytes.to_vec());
-        let result = self
+        let integrity = Integrity::from(bytes);
+        let keyfile = format!("{key}.integrity");
+        let keybody = ByteStream::from(integrity.to_string().as_bytes().to_vec());
+
+        if let Err(failure) = self
             .client
             .put_object()
             .bucket(&self.bucket)
-            .key(key)
-            .body(body)
-            .content_type("application/octet-stream")
+            .key(keyfile)
+            .body(keybody)
+            .content_type("text/plain")
             .send()
-            .await;
+            .await
+        {
+            return Err(ServalError::StorageError(format!(
+                "failed to write integrity key file to S3; error={failure}"
+            )));
+        }
 
-        match result {
-            Ok(_resp) => Ok(sri),
+        match self.store_by_integrity(&integrity, bytes).await {
+            Ok(integrity) => Ok(integrity),
             Err(e) => {
                 log::info!("Error storing data in s3: {e:?}");
 
                 Err(ServalError::StorageError(format!(
-                    "unable to store executable! key={}; error={}",
-                    key,
-                    e.message().unwrap_or("cannot get error message from AWS")
+                    "unable to store executable! key={key}; integrity={integrity}; error={e}"
                 )))
             }
         }
     }
 }
+

--- a/agent/src/storage/bucket.rs
+++ b/agent/src/storage/bucket.rs
@@ -114,19 +114,22 @@ impl S3Storage {
             .bucket(&self.bucket)
             .key(&keyfile)
             .send()
-            .await {
-                Ok(object) => {
-                    let chunks = object.body.collect().await?;
-                    let bytes = chunks.into_bytes().to_vec();
-                    let integrity_string = String::from_utf8(bytes)?;
-                    let encoded = encode(&integrity_string);
-                    Ok(encoded.to_string())
-                },
-                Err(e) => {
-                    log::info!("integrity checksum not found for key={key}; keyfile={keyfile}; error={e}");
-                    Err(ServalError::S3GetError(e))
-                },
+            .await
+        {
+            Ok(object) => {
+                let chunks = object.body.collect().await?;
+                let bytes = chunks.into_bytes().to_vec();
+                let integrity_string = String::from_utf8(bytes)?;
+                let encoded = encode(&integrity_string);
+                Ok(encoded.to_string())
             }
+            Err(e) => {
+                log::info!(
+                    "integrity checksum not found for key={key}; keyfile={keyfile}; error={e}"
+                );
+                Err(ServalError::S3GetError(e))
+            }
+        }
     }
 
     /// Store data by key.
@@ -162,4 +165,3 @@ impl S3Storage {
         }
     }
 }
-

--- a/agent/src/storage/mod.rs
+++ b/agent/src/storage/mod.rs
@@ -217,8 +217,6 @@ impl Storage {
             None
         };
 
-        // Consider comparing integrity hashes.
-
         if let Some(result) = local_result {
             result
         } else if let Some(result) = bucket_result {

--- a/agent/src/storage/mod.rs
+++ b/agent/src/storage/mod.rs
@@ -90,13 +90,13 @@ impl Storage {
     // This implementation is just a bunch of painful by-hand delegation logic.
     // I'd like to golf it down.
 
-    pub async fn data_by_sri(
+    pub async fn data_by_integrity(
         &self,
         integrity: Integrity,
     ) -> ServalResult<StreamBody<ReaderStream<SendableStream>>> {
         if !self.has_storage() {
             let proxy = make_proxy_client().await?;
-            let bytes = proxy.data_by_sri(&integrity.to_string()).await?;
+            let bytes = proxy.data_by_integrity(&integrity.to_string()).await?;
             let reader = ReaderStream::new(vec_to_byte_stream(bytes));
             return Ok(StreamBody::new(reader));
         }
@@ -124,7 +124,7 @@ impl Storage {
     /// Check if the given manifest is present in our store, using the fully-qualified name.
     ///
     /// Never checks a proxy; this is intended to be a local check.
-    pub async fn data_exists_by_sri(&self, integrity: &Integrity) -> ServalResult<bool> {
+    pub async fn data_exists_by_integrity(&self, integrity: &Integrity) -> ServalResult<bool> {
         if let Some(local) = &self.local {
             if let Ok(_v) = local.data_exists_by_integrity(integrity).await {
                 return Ok(true);

--- a/agent/src/storage/mod.rs
+++ b/agent/src/storage/mod.rs
@@ -94,11 +94,9 @@ impl Storage {
     /// integrity hash of the data.
     pub async fn store_by_integrity(&self, bytes: &[u8]) -> ServalResult<Integrity> {
         if !self.has_storage() {
-            // let proxy = make_proxy_client().await?;
-            // return proxy.store_executable(name, version, bytes.to_vec()).await;
-            todo!();
+            let proxy = make_proxy_client().await?;
+            return proxy.store_by_integrity(bytes.to_vec()).await;
         }
-
 
         let local_result = if let Some(local) = &self.local {
             Some(local.store_by_integrity(bytes).await)

--- a/api-client/src/lib.rs
+++ b/api-client/src/lib.rs
@@ -182,7 +182,7 @@ impl ServalApiClient {
         }
     }
 
-    pub async fn data_by_sri(&self, address: &str) -> ApiResult<Vec<u8>> {
+    pub async fn data_by_integrity(&self, address: &str) -> ApiResult<Vec<u8>> {
         let url = self.build_url(&format!("storage/data/{address}"));
         let response = reqwest::get(&url).await?;
         if response.status().is_success() {

--- a/api-client/src/lib.rs
+++ b/api-client/src/lib.rs
@@ -114,7 +114,8 @@ impl ServalApiClient {
         // StatusCode.CREATED  + ssri string
         if response.status().is_success() {
             let body = response.text().await?;
-            Ok(Integrity::from(body))
+            let integrity: Integrity = body.parse()?;
+            Ok(integrity)
         } else {
             Err(ServalError::StorageError(response.text().await?))
         }
@@ -162,7 +163,8 @@ impl ServalApiClient {
         let response = client.put(url).body(executable).send().await?;
         if response.status().is_success() {
             let body = response.text().await?;
-            Ok(Integrity::from(body))
+            let integrity: Integrity = body.parse()?;
+            Ok(integrity)
         } else {
             Err(ServalError::StorageError(response.text().await?))
         }

--- a/justfile
+++ b/justfile
@@ -30,8 +30,8 @@ help:
 
 # Lint and automatically fix what we can fix
 @lint:
-    cargo clippy --fix --allow-dirty --allow-staged
-    cargo +nightly fmt
+    cargo clippy --fix --allow-dirty --allow-staged --all-targets
+    cargo +nightly fmt --all
 
 # Install required linting/testing tools via cargo.
 @install-tools:

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -41,7 +41,7 @@ pub enum ServalError {
     DataNotFound(String),
 
     /// This job has no metadata
-    #[error("no manifest found for task `{0}`")]
+    #[error("no manifest found for `{0}`")]
     ManifestNotFound(String),
 
     /// Could not locate the named executable


### PR DESCRIPTION
Added a layer of indirection to S3 storage as a cheap index. Instead of writing data to the user-provided key, we write an object containing the integrity hash for the data. We then create an object that contains the data using the integrity hash as a key. Re-implemented all data stores and fetches in the bucket via this indirection. This is of course invisible to clients of the storage layer.

Implemented `HEAD /v1/storage/data/*address` via `has_content_address()`, which is now possible that the bucket storage supports it.

The term sri is now gone from all API surfaces. Instead we use "integrity" as the word for this concept.

Improved some error reporting, and fixed a bug with how the cli reported hashes. (It was reporting hashes of the hashes instead of printing the hashes, because I held the API wrong.)
