### PR TITLE
'just install-tools' should ensure that the nightly toolchain is installed

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,6 +35,7 @@ help:
 
 # Install required linting/testing tools via cargo.
 @install-tools:
+    rustup install nightly
     cargo install cargo-nextest
     cargo install cargo-deny
 


### PR DESCRIPTION
Per https://serval.slack.com/archives/C04BKH1J31S/p1682721245996159