### PR TITLE
A meta endpoint serving hostname (for now) + more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199523ba70af2b447640715e8c4bd2b5360313a71d2d69361ae4dd1dc31487dd"
+dependencies = [
+ "libc",
+ "windows",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +2849,7 @@ dependencies = [
  "engine",
  "env_logger",
  "futures",
+ "gethostname",
  "http",
  "hyper",
  "log",
@@ -4096,6 +4107,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -16,6 +16,7 @@ dotenvy = "0.15.6"
 engine = { path = "../engine" }
 env_logger = { workspace = true }
 futures = "0.3.28"
+gethostname = "0.4.2"
 http = "0.2.8"
 hyper = "0.14.23"
 log = "0.4.17"

--- a/agent/src/api/mod.rs
+++ b/agent/src/api/mod.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
 use axum::extract::State;
+use gethostname::gethostname;
 use axum::http::{Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use http::header::HeaderValue;
+use serde::Serialize;
 
 use crate::structures::AppState;
 
@@ -51,4 +53,18 @@ pub async fn ping() -> String {
 pub async fn monitor_status(_state: State<AppState>) -> impl IntoResponse {
     metrics::increment_counter!("monitor:status");
     StatusCode::NOT_IMPLEMENTED
+}
+
+#[derive(Serialize)]
+pub struct AgentMetadata {
+    hostname: String,
+}
+
+/// Provide agent metadata.
+pub async fn meta() -> String {
+    metrics::increment_counter!("meta");
+    let meta = AgentMetadata {
+        hostname: gethostname().into_string().expect("Failed to get hostname"),
+    };
+    serde_json::to_string(&meta).expect("Failed to serialize agent metadata")
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -236,7 +236,8 @@ fn init_router(state: &Arc<RunnerState>) -> Router {
 
     let mut router: Router<Arc<RunnerState>, Body> = Router::new()
         .route("/monitor/ping", get(ping))
-        .route("/monitor/status", get(monitor_status));
+        .route("/monitor/status", get(monitor_status))
+        .route("/meta", get(meta));
     router = v1::mesh::mount(router);
 
     // NOTE: We have two of these now. If we develop a third, generalize this pattern.


### PR DESCRIPTION
A `/meta` endpoint serving (for now) the agent's hostname.
This is the most basic implementation; other metadata could/should probably be contained in here as well.